### PR TITLE
Add authentication expiration

### DIFF
--- a/.env
+++ b/.env
@@ -33,6 +33,7 @@ AWS_S3_GATEWAY=
 AWS_IAM_ROLE=
 SERVER_NAME=hsdstest
 PASSWORD_SALT=
+AUTH_EXPIRATION=
 PUBLIC_DNS=hsds.hdf.test
 GREETING=Welcome to HSDS!
 ABOUT=HSDS is a webservice for HDF data

--- a/docker-compose-internal-lb.yml
+++ b/docker-compose-internal-lb.yml
@@ -78,6 +78,7 @@ services:
       - GREETING=${GREETING}
       - ABOUT=${ABOUT}
       - TOP_LEVEL_DOMAINS=${TOP_LEVEL_DOMAINS}
+      - AUTH_EXPIRATION=${AUTH_EXPIRATION}
 
     ports:
       - ${SN_PORT}:${SN_PORT}

--- a/docker-compose.openio.yml
+++ b/docker-compose.openio.yml
@@ -17,7 +17,6 @@ services:
       - AWS_REGION=${AWS_REGION}
       - BUCKET_NAME=${BUCKET_NAME}
       - LOG_LEVEL=${LOG_LEVEL}
-      - AUTH_EXPIRATION=${AUTH_EXPIRATION}
     ports:
       - ${HEAD_PORT}:${HEAD_PORT}
 
@@ -71,6 +70,7 @@ services:
       - GREETING=${GREETING}
       - ABOUT=${ABOUT}
       - TOP_LEVEL_DOMAINS=${TOP_LEVEL_DOMAINS}
+      - AUTH_EXPIRATION=${AUTH_EXPIRATION}
 
     ports:
       - ${SN_PORT}:${SN_PORT}

--- a/docker-compose.openio.yml
+++ b/docker-compose.openio.yml
@@ -17,6 +17,7 @@ services:
       - AWS_REGION=${AWS_REGION}
       - BUCKET_NAME=${BUCKET_NAME}
       - LOG_LEVEL=${LOG_LEVEL}
+      - AUTH_EXPIRATION=${AUTH_EXPIRATION}
     ports:
       - ${HEAD_PORT}:${HEAD_PORT}
 

--- a/docker-compose.posix.yml
+++ b/docker-compose.posix.yml
@@ -83,6 +83,7 @@ services:
       - GREETING=${GREETING}
       - ABOUT=${ABOUT}
       - TOP_LEVEL_DOMAINS=${TOP_LEVEL_DOMAINS}
+      - AUTH_EXPIRATION=${AUTH_EXPIRATION}
 
     ports:
       - ${SN_PORT}:${SN_PORT}

--- a/docker-compose.secure.yml
+++ b/docker-compose.secure.yml
@@ -64,6 +64,7 @@ services:
       - VIRTUAL_PORT=${SN_PORT}
       - LETSENCRYPT_HOST=${PUBLIC_DNS}
       - LETSENCRYPT_EMAIL=jguerrero@teravisiontech.com
+      - AUTH_EXPIRATION=${AUTH_EXPIRATION}
     depends_on:
       - head
   proxy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,7 @@ services:
       - GREETING=${GREETING}
       - ABOUT=${ABOUT}
       - TOP_LEVEL_DOMAINS=${TOP_LEVEL_DOMAINS}
+      - AUTH_EXPIRATION=${AUTH_EXPIRATION}
     ports:
       - ${SN_PORT}:${SN_PORT}
     depends_on:

--- a/hsds/config.py
+++ b/hsds/config.py
@@ -14,6 +14,7 @@ import sys
 
 cfg = {
     'allow_noauth': True,  # enable unauthenticated requests
+    'auth_expiration': -1, # set an expiration for credential caching
     'default_public': False, # new domains are publically readable by default
     'aws_access_key_id': 'xxx',  # Replace with access key for account
     'aws_secret_access_key': 'xxx',   # Replace with secret key for account

--- a/runall.sh
+++ b/runall.sh
@@ -37,11 +37,6 @@ echo "Using compose file: ${COMPOSE_FILE}"
 
 [[ -z ${HSDS_ENDPOINT} ]] && echo "HSDS_ENDPOINT is not set" && exit 1
 
-# Do not allow credentials to expire by default.
-if [[ -z ${AUTH_EXPIRATION} ]] ; then
-  export AUTH_EXPIRATION="-1"
-fi
-
 if [[ -z ${PUBLIC_DNS} ]] ; then
   if [[ ${HSDS_ENDPOINT} == "https://"* ]] ; then
      export PUBLIC_DNS=${HSDS_ENDPOINT:8}

--- a/runall.sh
+++ b/runall.sh
@@ -37,6 +37,11 @@ echo "Using compose file: ${COMPOSE_FILE}"
 
 [[ -z ${HSDS_ENDPOINT} ]] && echo "HSDS_ENDPOINT is not set" && exit 1
 
+# Do not allow credentials to expire by default.
+if [[ -z ${AUTH_EXPIRATION} ]] ; then
+  export AUTH_EXPIRATION="-1"
+fi
+
 if [[ -z ${PUBLIC_DNS} ]] ; then
   if [[ ${HSDS_ENDPOINT} == "https://"* ]] ; then
      export PUBLIC_DNS=${HSDS_ENDPOINT:8}


### PR DESCRIPTION
Re-authentication is required every `AUTH_EXPIRATION` seconds if this is set and > 0. By default, no re-authentication is required in order to preserve old behavior. Credentials set in the `passwd.txt` file never expire.

I did not see any authentication tests, so if they exist they have not been updated. Kubernetes deployment files have also not been updated since I am not as familiar with it.