### PR TITLE
Make hsds available as an application

### DIFF
--- a/hsds/app.py
+++ b/hsds/app.py
@@ -1,7 +1,6 @@
 import argparse
 import asyncio
 import os
-import sys
 
 from aiohttp import web
 

--- a/hsds/app.py
+++ b/hsds/app.py
@@ -36,8 +36,10 @@ def main():
     args = parser.parse_args()
 
     os.environ['HSDS_ENDPOINT'] = 'http://localhost:5101'
+    os.environ['HEAD_ENDPOINT'] = 'http://localhost:5100'
     os.environ['PUBLIC_DNS'] = 'localhost:5101'
     os.environ['LOG_LEVEL'] = 'DEBUG'
+    os.environ['STANDALONE_APP'] = 'True'
 
     os.environ['TARGET_SN_COUNT'] = '1'
     os.environ['TARGET_DN_COUNT'] = '1'
@@ -46,12 +48,13 @@ def main():
     os.environ['AWS_ACCESS_KEY_ID'] = args.access_key_id[0]
     os.environ['BUCKET_NAME'] = args.bucket_name[0]
     os.environ['PASSWORD_FILE'] = args.password_file[0]
-    
+
     log.info('APP about to start')
-    
+
     from . import datanode, servicenode, headnode
 
     loop = asyncio.get_event_loop()
+
 
     head_runner = web.AppRunner(headnode.create_app(loop))
     dn_runner = web.AppRunner(datanode.create_app(loop))
@@ -59,11 +62,11 @@ def main():
 
     log.info('Runners created')
 
-    loop.create_task(start_app_runner(
+    loop.run_until_complete(start_app_runner(
         head_runner, 'localhost', config.get('head_port')))
-    loop.create_task(start_app_runner(
+    loop.run_until_complete(start_app_runner(
         dn_runner, 'localhost', config.get('dn_port')))
-    loop.create_task(start_app_runner(
+    loop.run_until_complete(start_app_runner(
         sn_runner, 'localhost', config.get('sn_port')))
 
     log.info('Loop about to start')

--- a/hsds/app.py
+++ b/hsds/app.py
@@ -15,8 +15,24 @@ async def start_app_runner(runner, address, port):
     await site.start()
 
 
+_HELP_USAGE = "Starts hsds a REST-based service for HDF5 data."
+
+_HELP_EPILOG = """Examples:
+
+- with openio/sds data storage:
+
+  hsds --s3-gateway http://localhost:6007 --access-key-id demo:demo --secret-access-key DEMO_PASS --password-file ./admin/config/passwd.txt --bucket-name hsds.test
+
+- with a POSIX-based storage for 'hsds.test' sub-folder in the './data' folder:
+
+  hsds --bucket-dir ./data/hsds.test
+"""
+
 def main():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        usage=_HELP_USAGE,
+        epilog=_HELP_EPILOG)
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument(
         '--bucket-dir', nargs=1, type=str, dest='bucket_dir',

--- a/hsds/app.py
+++ b/hsds/app.py
@@ -1,0 +1,82 @@
+import argparse
+import asyncio
+import os
+import sys
+
+from aiohttp import web
+
+from . import config
+from . import hsds_logger as log
+
+
+async def start_app_runner(runner, address, port):
+    await runner.setup()
+    site = web.TCPSite(runner, address, port)
+    await site.start()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--s3-gateway', nargs=1, required=True, type=str, dest='s3_gateway',
+        help='S3 service endpoint (e.g., "http://openio:6007")')
+    parser.add_argument(
+        '--access-key-id', nargs=1, required=True, type=str, dest='access_key_id',
+        help='s3 access key id (e.g., "demo:demo"')
+    parser.add_argument(
+        '--secret-access-key', nargs=1, required=True, type=str, dest='secret_access_key',
+        help='s3 secret access key (e.g., "DEMO_PASS"')
+    parser.add_argument(
+        '--bucket-name', nargs=1, required=True, type=str, dest='bucket_name',
+        help='Name of the bucket to use (e.g., "hsds.test"')
+
+    parser.add_argument(
+        '--password-file', nargs=1, default='', type=str, dest='password_file',
+        help="Path to file containing authentication passwords (default: No authentication)")
+    args = parser.parse_args()
+
+    os.environ['HSDS_ENDPOINT'] = 'http://localhost:5101'
+    os.environ['PUBLIC_DNS'] = 'localhost:5101'
+    os.environ['LOG_LEVEL'] = 'DEBUG'
+
+    os.environ['TARGET_SN_COUNT'] = '1'
+    os.environ['TARGET_DN_COUNT'] = '1'
+    os.environ['AWS_S3_GATEWAY'] = args.s3_gateway[0]
+    os.environ['AWS_SECRET_ACCESS_KEY'] = args.secret_access_key[0]
+    os.environ['AWS_ACCESS_KEY_ID'] = args.access_key_id[0]
+    os.environ['BUCKET_NAME'] = args.bucket_name[0]
+    os.environ['PASSWORD_FILE'] = args.password_file[0]
+    
+    log.info('APP about to start')
+    
+    from . import datanode, servicenode, headnode
+
+    loop = asyncio.get_event_loop()
+
+    head_runner = web.AppRunner(headnode.create_app(loop))
+    dn_runner = web.AppRunner(datanode.create_app(loop))
+    sn_runner = web.AppRunner(servicenode.create_app(loop))
+
+    log.info('Runners created')
+
+    loop.create_task(start_app_runner(
+        head_runner, 'localhost', config.get('head_port')))
+    loop.create_task(start_app_runner(
+        dn_runner, 'localhost', config.get('dn_port')))
+    loop.create_task(start_app_runner(
+        sn_runner, 'localhost', config.get('sn_port')))
+
+    log.info('Loop about to start')
+
+    runners = [head_runner, dn_runner, sn_runner]
+
+    try:
+        loop.run_forever()
+    except:
+        pass
+    finally:
+        log.info('Runners about to stop')
+
+        for runner in reversed(runners):
+            loop.run_until_complete(runner.cleanup())
+   

--- a/hsds/basenode.py
+++ b/hsds/basenode.py
@@ -796,8 +796,8 @@ def baseInit(loop, node_type):
     if config.get('MARATHON_APP_ID'):
         app["is_dcos"] = True
 
-
-    log.app = app
+    if not config.get('standalone_app'):
+        log.app = app
 
     app["loop"] = loop  # save loop instance
 

--- a/hsds/config.py
+++ b/hsds/config.py
@@ -63,7 +63,7 @@ cfg = {
     'top_level_domains': [],  # list of possible top-level domains, example: ["/home", "/shared"]
     'cors_domain': '*',     # domains allowed for CORS
     'admin_user': 'admin',   # use with admin privileges
-    'chaos_die': 0           # if > 0, have nodes randomly die after n seconds (for testing)
+    'chaos_die': 0,           # if > 0, have nodes randomly die after n seconds (for testing)
     'standalone_app': False,  # True when run as a single application
 }
 

--- a/hsds/config.py
+++ b/hsds/config.py
@@ -64,7 +64,7 @@ cfg = {
     'cors_domain': '*',     # domains allowed for CORS
     'admin_user': 'admin',   # use with admin privileges
     'chaos_die': 0           # if > 0, have nodes randomly die after n seconds (for testing)
-
+    'standalone_app': False,  # True when run as a single application
 }
 
 def get(x):

--- a/hsds/datanode.py
+++ b/hsds/datanode.py
@@ -175,10 +175,12 @@ async def bucketGC(app):
 # Main
 #
 
-def main():
-    log.info("datanode start")
-    loop = asyncio.get_event_loop()
+def create_app(loop):
+    """Create datanode aiohttp application
 
+    :param loop: The asyncio loop to use for the application
+    :rtype: aiohttp.web.Application
+    """
     metadata_mem_cache_size = int(config.get("metadata_mem_cache_size"))
     log.info("Using metadata memory cache size of: {}".format(metadata_mem_cache_size))
     chunk_mem_cache_size = int(config.get("chunk_mem_cache_size"))
@@ -221,6 +223,12 @@ def main():
 
     # run root/dataset GC
     asyncio.ensure_future(bucketGC(app), loop=loop)
+
+    return app
+
+def main():
+    log.info("datanode start")
+    app = create_app(asyncio.get_event_loop())
 
     # run the app
     port = int(config.get("dn_port"))

--- a/hsds/datanode.py
+++ b/hsds/datanode.py
@@ -32,7 +32,6 @@ from .async_lib import scanRoot, removeKeys
 from aiohttp.web_exceptions import HTTPNotFound, HTTPInternalServerError, HTTPForbidden, HTTPBadRequest
 
 
-
 async def init(loop):
     """Intitialize application and return app object"""
     app = baseInit(loop, 'dn')

--- a/hsds/headnode.py
+++ b/hsds/headnode.py
@@ -384,9 +384,12 @@ def init():
 # Main
 #
 
-def main():
-    log.info("Head node initializing")
-    loop = asyncio.get_event_loop()
+def create_app(loop):
+    """Create headnode aiohttp application
+
+    :param loop: The asyncio loop to use for the application
+    :rtype: aiohttp.web.Application
+    """
     app = init()  
 
     # create a client Session here so that all client requests
@@ -394,6 +397,14 @@ def main():
     app["loop"] = loop
 
     asyncio.ensure_future(healthCheck(app), loop=loop)
+
+    return app
+
+
+def main():
+    log.info("Head node initializing")
+    app = create_app(asyncio.get_event_loop())
+
     head_port = config.get("head_port")
     log.info("Starting service on port: {}".format(head_port))
     log.debug("debug test")

--- a/hsds/servicenode.py
+++ b/hsds/servicenode.py
@@ -116,10 +116,12 @@ async def init(loop):
 #
 
 
-def main():
-    log.info("Service node initializing")
-    loop = asyncio.get_event_loop()
-    # create the app object
+def create_app(loop):
+    """Create servicenode aiohttp application
+
+    :param loop: The asyncio loop to use for the application
+    :rtype: aiohttp.web.Application
+    """
     app = loop.run_until_complete(init(loop))
 
     metadata_mem_cache_size = int(config.get("metadata_mem_cache_size"))
@@ -144,6 +146,13 @@ def main():
     initUserDB(app)
 
     asyncio.ensure_future(healthCheck(app), loop=loop)
+
+    return app
+
+
+def main():
+    log.info("Service node initializing")
+    app = create_app(asyncio.get_event_loop())
 
     # run the app
     port = int(config.get("sn_port"))

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(name='hsds',
       zip_safe=False,
       classifiers=classifiers,
       entry_points={'console_scripts': [
+          'hsds = hsds.app:main',
           'hsds-datanode = hsds.datanode:main',
           'hsds-servicenode = hsds.servicenode:main',
           'hsds-headnode = hsds.headnode:main',


### PR DESCRIPTION
This PR builds on PR #26 which content is included here.
It is a first proposition to enable starting `hsds` as a simple application (issue #34).
There is room for improvement, but it passes the tests for both open.io and posix storage.
I takes a few options on top of those `hsds.config.get` is interpreting:

```
% hsds --help
usage: Starts hsds a REST-based service for HDF5 data.

optional arguments:
  -h, --help            show this help message and exit
  --bucket-dir BUCKET_DIR
                        Directory where to store the object store data
  --bucket-name BUCKET_NAME
                        Name of the bucket to use (e.g., "hsds.test").
  --host HOST           Address the service node is bounds with (default: localhost).
  -p PORT, --port PORT  Service node port (default: 5101).
  --s3-gateway S3_GATEWAY
                        S3 service endpoint (e.g., "http://openio:6007")
  --access-key-id ACCESS_KEY_ID
                        s3 access key id (e.g., "demo:demo")
  --secret-access-key SECRET_ACCESS_KEY
                        s3 secret access key (e.g., "DEMO_PASS")
  --password-file PASSWORD_FILE
                        Path to file containing authentication passwords (default: No authentication)

Examples:

- with openio/sds data storage:

  hsds --s3-gateway http://localhost:6007 --access-key-id demo:demo --secret-access-key DEMO_PASS --password-file ./admin/config/passwd.txt --bucket-name hsds.test

- with a POSIX-based storage for 'hsds.test' sub-folder in the './data' folder:

  hsds --bucket-dir ./data/hsds.test
```