### PR TITLE
Add basic Kerberos authentication

### DIFF
--- a/.env
+++ b/.env
@@ -34,6 +34,7 @@ AWS_IAM_ROLE=
 SERVER_NAME=hsdstest
 PASSWORD_SALT=
 AUTH_EXPIRATION=
+KRB5_REALM=
 PUBLIC_DNS=hsds.hdf.test
 GREETING=Welcome to HSDS!
 ABOUT=HSDS is a webservice for HDF data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,33 @@
-FROM hdfgroup/python:3.7
+# Build image for packages that need compilation.
+FROM hdfgroup/python:3.7 AS build
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get install -y gcc krb5-user libkrb5-dev
+RUN pip wheel -w /opt/wheels gssapi
+
+# Production image for runtime.
+FROM hdfgroup/python:3.7 AS runtime
 MAINTAINER John Readey <jreadey@hdfgroup.org>
+
+# Install krb5 libs and gssapi package.
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y krb5-user
+COPY --from=build /opt/wheels/* /opt/wheels/
+RUN pip install /opt/wheels/*
+
+# Install python packages from pip.
 RUN pip install azure-storage-blob
 RUN pip install aiofiles
 RUN pip install pyjwt
+
+# Copy config files.
 RUN mkdir /usr/local/src/hsds/ /usr/local/src/tests/
 COPY hsds /usr/local/src/hsds/
+COPY admin/config/krb5.conf /etc/krb5.conf
 COPY admin/config/passwd.txt /usr/local/src/hsds/
 COPY tests /usr/local/src/tests/
 COPY testall.py /usr/local/src/
 COPY entrypoint.sh  /
 
 EXPOSE 5100-5999
- 
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/admin/config/krb5.conf
+++ b/admin/config/krb5.conf
@@ -1,0 +1,9 @@
+# Empty krb5.conf file.
+# To authenticate against a Kerberos domain controller, update this
+# file with site-specific settings.
+
+[libdefaults]
+
+[realms]
+
+[domain_realm]

--- a/docker-compose-internal-lb.yml
+++ b/docker-compose-internal-lb.yml
@@ -79,6 +79,7 @@ services:
       - ABOUT=${ABOUT}
       - TOP_LEVEL_DOMAINS=${TOP_LEVEL_DOMAINS}
       - AUTH_EXPIRATION=${AUTH_EXPIRATION}
+      - KRB5_REALM=${KRB5_REALM}
 
     ports:
       - ${SN_PORT}:${SN_PORT}

--- a/docker-compose.openio.yml
+++ b/docker-compose.openio.yml
@@ -71,6 +71,7 @@ services:
       - ABOUT=${ABOUT}
       - TOP_LEVEL_DOMAINS=${TOP_LEVEL_DOMAINS}
       - AUTH_EXPIRATION=${AUTH_EXPIRATION}
+      - KRB5_REALM=${KRB5_REALM}
 
     ports:
       - ${SN_PORT}:${SN_PORT}

--- a/docker-compose.posix.yml
+++ b/docker-compose.posix.yml
@@ -84,6 +84,7 @@ services:
       - ABOUT=${ABOUT}
       - TOP_LEVEL_DOMAINS=${TOP_LEVEL_DOMAINS}
       - AUTH_EXPIRATION=${AUTH_EXPIRATION}
+      - KRB5_REALM=${KRB5_REALM}
 
     ports:
       - ${SN_PORT}:${SN_PORT}

--- a/docker-compose.secure.yml
+++ b/docker-compose.secure.yml
@@ -65,6 +65,7 @@ services:
       - LETSENCRYPT_HOST=${PUBLIC_DNS}
       - LETSENCRYPT_EMAIL=jguerrero@teravisiontech.com
       - AUTH_EXPIRATION=${AUTH_EXPIRATION}
+      - KRB5_REALM=${KRB5_REALM}
     depends_on:
       - head
   proxy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,7 @@ services:
       - ABOUT=${ABOUT}
       - TOP_LEVEL_DOMAINS=${TOP_LEVEL_DOMAINS}
       - AUTH_EXPIRATION=${AUTH_EXPIRATION}
+      - KRB5_REALM=${KRB5_REALM}
     ports:
       - ${SN_PORT}:${SN_PORT}
     depends_on:

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,45 @@
+# HSDS Authentication
+
+## Authentication Methods
+
+### Password file authentication
+By default, HSDS will load local usernames and passwords from a text file located at `admin/config/passwd.txt` when the container is built. The example password file contains three users:
+
+```bash
+# HSDS password file template
+#
+#
+# This file contians a list of usernames/passwords that will be used to authenticate
+# requests to HSDS.
+# Copy file to "passwd.txt" in the same directory before building and deploying HSDS.
+# For production use, replace the "test" password below with secret passwords and add
+# and any new accounts desired.
+# Text file get's copied to image at build time, so any changes require a new build/deployment.
+admin:admin
+test_user1:test
+test_user2:test
+```
+
+Password file authentication can be combined with any of the following authentication methods (except for no authentication) by explicitly specifying the `PASSWORD_FILE` environment variable. Other possible authentication methods are given below in order of priority.
+
+### Password-less authentication
+
+Password-less authentication is enabled when the `PASSWORD_FILE` environment variable is explicitly set empty, `PASSWORD_FILE=""`. In this mode users are still required to provide a password in the HTTP basic authentication header, but it is not checked and permissions are granted based solely on the username provided.
+
+### AWS DynamoDB authentication
+
+Users are authenticated against an AWS DynamoDB table when the environment variables `AWS_DYNAMODB_GATEWAY` and `AWS_DYNAMODB_USERS_TABLE` are set appropriately.
+
+### Salted password authentication
+
+In salted password authentication, a master password is provided at runtime via the `PASSWORD_SALT` environment variable. If given, passwords are calculated for each user based on the combination of the username with the salt. The password for each username is computed by first concatenating the username with `PASSWORD_SALT`, then taking the first 32 characters of the SHA512 hash. For example, if `PASSWORD_SALT=salt`, then the password for `admin` is `3c4a79782143337be4492be072abcfe9`.
+
+### Kerberos authentication
+
+In Kerberos authentication, usernames and passwords are authenticated against a remote Kerberos domain controller. Currently, single-sign on is not supported and passwords must be explicitly sent with each request. To use Kerberos authentication, a valid `krb5.conf` file must be present at `admin/config/krb5.conf` when the container is built. Additionally, the environment variable `KRB5_REALM` must be set at runtime to the Kerberos realm against which to authenticate, for example `KRB5_REALM=HDFGROUP.ORG`. 
+
+Note, the current implementation does not validate the authenticity of the Kerberos domain controller itself, and should only be used on trusted networks.
+
+## Credential caching
+
+By default, credentials are cached indefinitely to improve performance. However some authentication methods such as DynamoDB and Kerberos support dynamic passwords that can be changed outside of HSDS. In this case, the cache time can be changed by setting the `AUTH_EXPIRATION` environment variable to the number of seconds to store credentials for. For example, `AUTH_EXPIRATION=60` to cache credentials for one minute.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -20,7 +20,7 @@ test_user1:test
 test_user2:test
 ```
 
-Password file authentication can be combined with any of the following authentication methods (except for no authentication) by explicitly specifying the `PASSWORD_FILE` environment variable. Other possible authentication methods are given below in order of priority.
+Password file authentication can be combined with any of the following authentication methods (except for no authentication) by explicitly specifying the `PASSWORD_FILE` environment variable. To set the `PASSWORD_FILE` variable, the appropriate `docker-compose.*.yml` must be edited. Other possible authentication methods are given below in order of priority.
 
 ### Password-less authentication
 
@@ -36,7 +36,7 @@ In salted password authentication, a master password is provided at runtime via 
 
 ### Kerberos authentication
 
-In Kerberos authentication, usernames and passwords are authenticated against a remote Kerberos domain controller. Currently, single-sign on is not supported and passwords must be explicitly sent with each request. To use Kerberos authentication, a valid `krb5.conf` file must be present at `admin/config/krb5.conf` when the container is built. Additionally, the environment variable `KRB5_REALM` must be set at runtime to the Kerberos realm against which to authenticate, for example `KRB5_REALM=HDFGROUP.ORG`. 
+In Kerberos authentication, usernames and passwords are authenticated against a remote Kerberos domain controller. Currently, single-sign on is not supported and passwords must be explicitly sent with each request. To use Kerberos authentication, a valid `krb5.conf` file must be present at `admin/config/krb5.conf` when the container is built. Additionally, the environment variable `KRB5_REALM` must be set at runtime to the Kerberos realm against which to authenticate, for example `KRB5_REALM=HDFGROUP.ORG`.
 
 Note, the current implementation does not validate the authenticity of the Kerberos domain controller itself, and should only be used on trusted networks.
 

--- a/hsds/config.py
+++ b/hsds/config.py
@@ -32,6 +32,7 @@ cfg = {
     'azure_resource_id': '', # resource id for use with Azure Active Directory
     'root_dir': '',  # base directory to use for Posix storage
     'password_salt': '',
+    'krb5_realm': '', # Kerberos realm to authenticate against using GSSAPI.
     'bucket_name': '',  # set to usee a default bucket, otherwise bucket param is needed for all requests
     'head_host': 'localhost',
     'head_port': 5100,


### PR DESCRIPTION
In on-premises deployments, user accounts are often centrally managed. This PR adds basic authentication against a trusted Kerberos or Active Directory setup. 

Usernames are passwords are validated against the KDC, but the integrity of the KDC itself is not validated. This would require registering HSDS with the KDC and distributing private keys to all containers. Doable, but more complex and site-specific setup.

This does not implement Kerberos-based single-sign on (HTTP Negotiate) which also requires registering HSDS with the KDC, but the `gssapi` package can be used to implement this in the future.

