### PR TITLE
Do not install dependencies when building docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM hdfgroup/python:3.8
 MAINTAINER John Readey <jreadey@hdfgroup.org>
 RUN mkdir /usr/local/src/hsds-src/ /usr/local/src/hsds/
 COPY . /usr/local/src/hsds-src
-RUN pip install /usr/local/src/hsds-src/[azure]
+RUN pip install /usr/local/src/hsds-src/ --no-deps
 COPY entrypoint.sh  /
 
 EXPOSE 5100-5999


### PR DESCRIPTION
Following https://github.com/HDFGroup/hsds/pull/35#issuecomment-606951083 :
"""
Going back to #26 - I notice that build.sh installs a lot of azure packages each time. E.g. azure-datalake-store. Is there a way to avoid these? I thought the required packages where being installed in the Docker base image. I prefer not having to deal with possible package updates with every build.
"""

This PR removes the check/installation of dependencies when installing `hsds`, so it is expected that all dependencies are already available in the base docker image.