### PR TITLE
Use sdist and install from tarball in docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - pip install pyyaml
   - pyflakes hsds/*.py
   - pyflakes hsds/util/*.py
-  - python setup.py build
+  - python setup.py sdist
   - cp admin/config/passwd.default admin/config/passwd.txt
   - docker build -t hdfgroup/hsds .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
   - pip install pyyaml
   - pyflakes hsds/*.py
   - pyflakes hsds/util/*.py
+  - python setup.py build
   - cp admin/config/passwd.default admin/config/passwd.txt
   - docker build -t hdfgroup/hsds .
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM hdfgroup/python:3.8
 MAINTAINER John Readey <jreadey@hdfgroup.org>
 RUN mkdir /usr/local/src/hsds-src/ /usr/local/src/hsds/
-COPY . /usr/local/src/hsds-src
-RUN pip install /usr/local/src/hsds-src/ --no-deps
+COPY ./dist/hsds-*.tar.gz /usr/local/src/hsds-src
+RUN pip install /usr/local/src/hsds-src/hsds-*.tar.gz --no-deps --no-binary hsds
 RUN rm -rf /usr/local/src/hsds-src
 RUN mkdir /etc/hsds/
 COPY admin/config/config.yml /etc/hsds/

--- a/build.sh
+++ b/build.sh
@@ -30,5 +30,8 @@ fi
 echo "clean stopped containers"
 docker rm -v $(docker ps -aq -f status=exited)
 
+echo "building hsds sdist"
+python setup.py build
+
 echo "building docker image"
 docker build -t hdfgroup/hsds .

--- a/build.sh
+++ b/build.sh
@@ -31,7 +31,7 @@ echo "clean stopped containers"
 docker rm -v $(docker ps -aq -f status=exited)
 
 echo "building hsds sdist"
-python setup.py build
+python setup.py sdist
 
 echo "building docker image"
 docker build -t hdfgroup/hsds .


### PR DESCRIPTION
Following https://github.com/HDFGroup/hsds/pull/35#issuecomment-632186279, this PR proposes to build the source tarball and use it instead of the source directory to build the docker image so as to avoid copying the whole source directory.

`--no-binary hsds` is there to avoid building (and thus storing) the corresponding wheel in the docker image.

This is probably a bit cleaner but I think it has little advantage over the current way: it makes sure only relevant files are used to install `hsds` but at the expense of an extra `python setup.py build` step...
