### PR TITLE
Copy the passwd.txt into the docker container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN pip install /usr/local/src/hsds-src/ --no-deps
 RUN rm -rf /usr/local/src/hsds-src
 RUN mkdir /etc/hsds/
 COPY admin/config/config.yml /etc/hsds/
+COPY admin/config/passwd.txt /etc/hsds/
 COPY entrypoint.sh  /
 
 EXPOSE 5100-5999


### PR DESCRIPTION
During setup we found that the passwd.txt file was not copied into the docker container. This will fix that issue.

Signed-off-by: Michael Jackson <mjackson@caboose.bluequartz.net>