### PR TITLE
add support for specifying k8s_namespace

### DIFF
--- a/admin/config/config.yml
+++ b/admin/config/config.yml
@@ -69,4 +69,4 @@ standalone_app: false   # True when run as a single application
 blosc_nthreads: 2  # number of threads to use for blosc compression.  Set to 0 to have blosc auto-determine thread count
 http_compression: true  # Use HTTP compression 
 k8s_app_label: hsds  # The app label for k8s deployments
-
+k8s_namespace: null # Specifies if a the client should be limited to a specific namespace. Useful for some RBAC configurations.

--- a/hsds/basenode.py
+++ b/hsds/basenode.py
@@ -311,7 +311,14 @@ async def k8s_register(app):
     v1 = k8s_client.CoreV1Api()
     # TBD - use the async version
     k8s_app_label = config.get("k8s_app_label")
-    ret = v1.list_pod_for_all_namespaces(watch=False)
+    # If a namespace is specified restrict pod
+    # listing to that namespace otherwise list
+    # pods from all namespaces.
+    k8s_namespace = config.get("k8s_namespace")
+    if k8s_namespace:
+        ret = v1.list_namespaced_pod(k8s_namespace)
+    else:
+        ret = v1.list_pod_for_all_namespaces(watch=False)
     pod_ips = []
     sn_urls = {}
     dn_urls = {}


### PR DESCRIPTION
Hi, thanks for working on hsds!

This allows toggling between the `list_namespaced_pod` and `list_pod_for_all_namespaces`
methods in the python kubernetes client when initializing an hsds deployment in-cluster.
Specifying a specific namespace is useful for some shared tenant deployments with
strict RBAC policies.

See this link for details:
https://kubernetes.io/docs/reference/access-authn-authz/rbac/#service-account-permissions
In deployments similar to what is described in the first example and where it is not possible to apply the RBAC configuration in `admin/kubernetes/k8s_rbac.yml`, listing namespaces will fail with the following exception:
```
======== Running on http://0.0.0.0:5101 ========
(Press CTRL+C to quit)
INFO> health check start
INFO> node_state: INITIALIZING
INFO> k8s_register
Task exception was never retrieved
future: <Task finished name='Task-3' coro=<healthCheck() done, defined at /usr/local/lib/python3.8/site-packages/hsds/basenode.py:414> exception=ApiException()>
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/hsds/basenode.py", line 430, in healthCheck
    await k8s_register(app)
  File "/usr/local/lib/python3.8/site-packages/hsds/basenode.py", line 314, in k8s_register
    ret = v1.list_pod_for_all_namespaces(watch=False)
  File "/usr/local/lib/python3.8/site-packages/kubernetes/client/api/core_v1_api.py", line 14098, in list_pod_for_all_namespaces
    (data) = self.list_pod_for_all_namespaces_with_http_info(**kwargs)  # noqa: E501
  File "/usr/local/lib/python3.8/site-packages/kubernetes/client/api/core_v1_api.py", line 14179, in list_pod_for_all_namespaces_with_http_info
    return self.api_client.call_api(
  File "/usr/local/lib/python3.8/site-packages/kubernetes/client/api_client.py", line 340, in call_api
    return self.__call_api(resource_path, method,
  File "/usr/local/lib/python3.8/site-packages/kubernetes/client/api_client.py", line 172, in __call_api
    response_data = self.request(
  File "/usr/local/lib/python3.8/site-packages/kubernetes/client/api_client.py", line 362, in request
    return self.rest_client.GET(url,
  File "/usr/local/lib/python3.8/site-packages/kubernetes/client/rest.py", line 237, in GET
    return self.request("GET", url,
  File "/usr/local/lib/python3.8/site-packages/kubernetes/client/rest.py", line 231, in request
    raise ApiException(http_resp=r)
kubernetes.client.rest.ApiException: (403)
Reason: Forbidden
HTTP response headers: HTTPHeaderDict({'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'X-Content-Type-Options': 'nosniff', 'Date': 'Wed, 02 Dec 2020 20:12:07 GMT', 'Content-Length': '282'})
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"pods is forbidden: User \"REDACTED\" cannot list resource \"pods\" in API group \"\" at the cluster scope","reason":"Forbidden","details":{"kind":"pods"},"code":403}
```
 Setting the new `k8s_namespace` associated with the restricted user account alleviates this issue for me on on Kubernetes `v1.18.6`.

Kevin