### PR TITLE
Fix empty value when integers in select param

### DIFF
--- a/awslambda/chunkread/hsds/util/dsetUtil.py
+++ b/awslambda/chunkread/hsds/util/dsetUtil.py
@@ -226,14 +226,14 @@ def getSliceQueryParam(request, dim, extent, body=None):
         dim_query = query_array[dim].strip()
 
         if dim_query.find(':') < 0:
-            # just a number - return start = stop for this value
+            # just a number - return stop = start + 1 for this value
             try:
                 start = int(dim_query)
             except ValueError:
                 msg = "Bad Request: invalid selection parameter (can't convert to int) for dimension: " + str(dim)
                 log.warn(msg)
                 raise KeyError()
-            stop = start
+            stop = start + 1
         elif dim_query == ':':
             # select everything
             pass

--- a/hsds/util/dsetUtil.py
+++ b/hsds/util/dsetUtil.py
@@ -374,14 +374,14 @@ def getSliceQueryParam(request, dim, extent, body=None):
         dim_query = query_array[dim].strip()
 
         if dim_query.find(':') < 0:
-            # just a number - return start = stop for this value
+            # just a number - return stop = start + 1 for this value
             try:
                 start = int(dim_query)
             except ValueError:
                 msg = "Bad Request: invalid selection parameter (can't convert to int) for dimension: " + str(dim)
                 log.warn(msg)
                 raise HTTPBadRequest(reason=msg)
-            stop = start
+            stop = start + 1
         elif dim_query == ':':
             # select everything
             pass


### PR DESCRIPTION
Putting integers in the `select` query parameter of GET value would give an empty value.

`select=[n]` would indeed be transformed to the empty slice `[n:n]`.

In this PR, `select=[n]` is interpreted as `[n:n+1]`, yielding a slice containing the element `n`.