### PR TITLE
Numcodecs shuffle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.log
 *.vscode
 passwd.txt
+*.egg-info

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,57 @@
-FROM hdfgroup/python:3.8.5
-MAINTAINER John Readey <jreadey@hdfgroup.org>
-RUN mkdir /usr/local/src/hsds-src/ /usr/local/src/hsds/
-COPY . /usr/local/src/hsds-src
-RUN pip install /usr/local/src/hsds-src/ --no-deps
-RUN rm -rf /usr/local/src/hsds-src
-RUN mkdir /etc/hsds/
-COPY admin/config/config.yml /etc/hsds/
-COPY entrypoint.sh  /
+FROM continuumio/miniconda3@sha256:7838d0ce65783b0d944c19d193e2e6232196bada9e5f3762dc7a9f07dc271179 AS hsds-base
+LABEL maintainer="Aleksandar Jelenak <help@hdfgroup.org>"
+RUN conda update conda -y && \
+    conda config --add channels conda-forge && \
+    conda config --set channel_priority strict && \
+    conda install conda-pack && \
+    conda create --name hsds --yes python=3.8
+RUN conda install --name hsds --yes \
+        curl \
+        git \
+        compilers \
+        psutil \
+        numpy \
+        pytz \
+        requests \
+        aiobotocore \
+        azure-storage-blob \
+        aiofiles \
+        aiohttp \
+        aiohttp-cors \
+        pyjwt \
+        pyyaml \
+        pip \
+        wheel
+# Install numcodecs from the specific commit since we need the brand new shuffle codec...
+RUN DISABLE_NUMCODECS_AVX2=1 CFLAGS=-DHAVE_UNISTD_H \
+    conda run -n hsds --no-capture-output pip install --no-cache-dir \
+    git+https://github.com/zarr-developers/numcodecs.git@d16d1eac5198166a24726ffe808e3dcfcab9700d#egg=numcodecs \
+    && conda remove --name hsds --yes git compilers \
+    && conda run -n hsds --no-capture-output pip install --no-cache-dir kubernetes
+RUN conda-pack -n hsds -o /tmp/hsds-env.tar \
+    && mkdir -p /opt/env/hsds \
+    && cd /opt/env/hsds \
+    && tar xf /tmp/hsds-env.tar \
+    && rm /tmp/hsds-env.tar
+RUN /opt/env/hsds/bin/conda-unpack
+
+#
+#
+#
+
+FROM debian:buster-slim AS hsds
+LABEL maintainer="Aleksandar Jelenak <help@hdfgroup.org>"
+
+COPY --from=hsds-base /opt/env/hsds /opt/env/hsds
+
+# Install HSDS
+RUN mkdir /usr/local/src/hsds-src/ /usr/local/src/hsds/ /etc/hsds/
+COPY hsds/ /usr/local/src/hsds-src
+COPY hsds/admin/config/config.yml /etc/hsds/
+COPY hsds/entrypoint.sh  /
+RUN /bin/bash -c "source /opt/env/hsds/bin/activate \
+    && pip install /usr/local/src/hsds-src/ --no-deps \
+    && rm -rf /usr/local/src/hsds-src"
 
 EXPOSE 5100-5999
-
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/bin/bash", "-c", "source /opt/env/hsds/bin/activate && /entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,9 @@ COPY --from=hsds-base /opt/env/hsds /opt/env/hsds
 
 # Install HSDS
 RUN mkdir /usr/local/src/hsds-src/ /usr/local/src/hsds/ /etc/hsds/
-COPY hsds/ /usr/local/src/hsds-src
-COPY hsds/admin/config/config.yml /etc/hsds/
-COPY hsds/entrypoint.sh  /
+COPY . /usr/local/src/hsds-src
+COPY admin/config/config.yml /etc/hsds/
+COPY entrypoint.sh  /
 RUN /bin/bash -c "source /opt/env/hsds/bin/activate \
     && pip install /usr/local/src/hsds-src/ --no-deps \
     && rm -rf /usr/local/src/hsds-src"

--- a/testall.py
+++ b/testall.py
@@ -13,13 +13,13 @@
 import os
 import sys
 
-PYTHON_CMD="python3"
+PYTHON_CMD = "python3"
 
 unit_tests = ('arrayUtilTest', 'chunkUtilTest', 'domainUtilTest',
     'dsetUtilTest', 'hdf5dtypeTest', 'idUtilTest', 'lruCacheTest', 'shuffleTest')
 
 integ_tests = ('uptest', 'setup_test', 'domain_test', 'group_test', 'link_test',
- 'attr_test', 'datatype_test', 'dataset_test', 'acl_test', 'value_test', 'pointsel_test', 'query_test', 'vlen_test' )
+ 'attr_test', 'datatype_test', 'dataset_test', 'acl_test', 'value_test', 'pointsel_test', 'query_test', 'vlen_test')
 
 skip_unit = False
 if len(sys.argv) > 1:
@@ -34,9 +34,9 @@ cwd = os.getcwd()
 no_server = False
 if len(sys.argv) > 1:
     if sys.argv[1] == '--unit':
-        integ_tests = () # skip integ tests
+        integ_tests = ()  # skip integ tests
     elif sys.argv[1] == '--integ':
-        unit_tests = () # skip unit tests
+        unit_tests = ()  # skip unit tests
 
 
 this_dir = os.path.dirname(os.path.realpath(sys.argv[0]))


### PR DESCRIPTION
The code in this branch:
1. Replaces the custom numba-based shuffle filter with the one from the numcodecs package.
1. New Dockerfile for HSDS containers that builds the numcodecs package from source (because its shuffle filter is not yet in any of the official releases). The Dockerfile uses the `continuumio/miniconda3` base image and yields an image of about 450MB.
1. Some PEP8 and gitignore housekeeping.