### PR TITLE
fix get_session import after aiobotocore 2.0.0

### DIFF
--- a/hsds/util/authUtil.py
+++ b/hsds/util/authUtil.py
@@ -18,7 +18,7 @@ import subprocess
 import os.path as pp
 import datetime
 from botocore.exceptions import ClientError
-from aiobotocore import get_session
+from aiobotocore.session import get_session
 from aiohttp.web_exceptions import HTTPBadRequest, HTTPUnauthorized
 from aiohttp.web_exceptions import HTTPForbidden, HTTPInternalServerError
 

--- a/hsds/util/awsLambdaClient.py
+++ b/hsds/util/awsLambdaClient.py
@@ -1,4 +1,4 @@
-from aiobotocore import get_session
+from aiobotocore.session import get_session
 from asyncio import CancelledError
 
 import datetime

--- a/hsds/util/query_marathon.py
+++ b/hsds/util/query_marathon.py
@@ -11,7 +11,7 @@
 ##############################################################################
 from aiohttp.web_exceptions import HTTPNotFound, HTTPInternalServerError
 
-from aiobotocore import get_session
+from aiobotocore.session import get_session
 
 from .. import hsds_logger as log
 from .httpUtil import http_get

--- a/hsds/util/s3Client.py
+++ b/hsds/util/s3Client.py
@@ -18,7 +18,7 @@ import datetime
 import json
 import time
 from aiobotocore.config import AioConfig
-from aiobotocore import get_session
+from aiobotocore.session import get_session
 from botocore.exceptions import ClientError
 from aiohttp.web_exceptions import HTTPNotFound, HTTPInternalServerError
 from aiohttp.web_exceptions import HTTPForbidden, HTTPBadRequest

--- a/tests/unit/storUtilTest.py
+++ b/tests/unit/storUtilTest.py
@@ -13,7 +13,7 @@ import asyncio
 import random
 import time
 import numpy as np
-from aiobotocore import get_session
+from aiobotocore.session import get_session
 import unittest
 import sys
 from aiohttp.web_exceptions import HTTPNotFound

--- a/tools/bucket_scan.py
+++ b/tools/bucket_scan.py
@@ -16,7 +16,7 @@ import os
 if "CONFIG_DIR" not in os.environ:
     os.environ["CONFIG_DIR"] = "../admin/config/"
 
-from aiobotocore import get_session
+from aiobotocore.session import get_session
 from aiohttp.web_exceptions import HTTPNotFound, HTTPInternalServerError
 from hsds.util.storUtil import releaseStorageClient, getStorKeys, getStorJSONObj
 from hsds.util.idUtil import getObjId

--- a/tools/create_toplevel_domain_json.py
+++ b/tools/create_toplevel_domain_json.py
@@ -28,7 +28,7 @@ from hsds import hsds_logger as log
 import asyncio
 import sys
 import time
-from aiobotocore import get_session
+from aiobotocore.session import get_session
 from aiohttp.client_exceptions import ClientOSError
 from hsds.util.domainUtil import validateDomain, getParentDomain
 from hsds.util.idUtil import getS3Key

--- a/tools/delete_bucket.py
+++ b/tools/delete_bucket.py
@@ -12,7 +12,7 @@
 import asyncio
 import sys
 import os
-from aiobotocore import get_session
+from aiobotocore.session import get_session
 
 if "CONFIG_DIR" not in os.environ:
     os.environ["CONFIG_DIR"] = "../admin/config/"

--- a/tools/get_s3json.py
+++ b/tools/get_s3json.py
@@ -13,7 +13,7 @@ import asyncio
 import sys
 import os
 import json
-from aiobotocore import get_session
+from aiobotocore.session import get_session
 from aiohttp.client_exceptions import ClientOSError
 
 if "CONFIG_DIR" not in os.environ:

--- a/tools/link_mod.py
+++ b/tools/link_mod.py
@@ -12,7 +12,7 @@
 import asyncio
 import sys
 import os
-from aiobotocore import get_session
+from aiobotocore.session import get_session
 from aiohttp.client_exceptions import ClientError
 from aiohttp.web_exceptions import HTTPNotFound, HTTPInternalServerError
 

--- a/tools/list_objects.py
+++ b/tools/list_objects.py
@@ -16,7 +16,7 @@ import os
 if "CONFIG_DIR" not in os.environ:
     os.environ["CONFIG_DIR"] = "../admin/config/"
 
-from aiobotocore import get_session
+from aiobotocore.session import get_session
 from hsds.util.storUtil import getStorKeys, isStorObj, releaseStorageClient
 from hsds import config
 

--- a/tools/root_delete.py
+++ b/tools/root_delete.py
@@ -12,7 +12,7 @@
 import asyncio
 import sys
 import os
-from aiobotocore import get_session
+from aiobotocore.session import get_session
 
 if "CONFIG_DIR" not in os.environ:
     os.environ["CONFIG_DIR"] = "../admin/config/"

--- a/tools/root_scan.py
+++ b/tools/root_scan.py
@@ -13,7 +13,7 @@ import asyncio
 import sys
 import os
 from datetime import datetime
-from aiobotocore import get_session
+from aiobotocore.session import get_session
 
 if "CONFIG_DIR" not in os.environ:
     os.environ["CONFIG_DIR"] = "../admin/config/"


### PR DESCRIPTION
In `aiobotocore` 2.0.0 remove `get_session` at top level, as point out in #110 
The fixs are import from `aiobotocore.sessio` 