### PR TITLE
Lambda socket dir

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -206,7 +206,7 @@ def lambda_handler(event, context):
                    password="lambda", 
                    islambda=True,
                    dn_count=target_dn_count, 
-                   readonly=readonly
+                   readonly=readonly,
                    socket_dir=socket_dir)
     hsds.run()
 

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -5,6 +5,7 @@ import json
 import time
 import logging
 import requests_unixsocket
+import uuid
 
 
 from hsds.hsds_app import HsdsApp
@@ -196,12 +197,17 @@ def lambda_handler(event, context):
         target_dn_count = - (-cpu_count // 2)
         print(f"setting dn count to: {target_dn_count}")
 
+    tmp_dir = "/tmp"
+    rand_name = uuid.uuid4().hex[:8]
+    socket_dir = f"{tmp_dir}/hs{rand_name}/"
+
     # instantiate hsdsapp object
     hsds = HsdsApp(username=function_name, 
                    password="lambda", 
                    islambda=True,
                    dn_count=target_dn_count, 
-                   readonly=readonly)
+                   readonly=readonly
+                   socket_dir=socket_dir)
     hsds.run()
 
     # wait for server to startup


### PR DESCRIPTION
Fixes an issue with lambda that was introduced about a month ago with changes supporting Windows (I think). Those changes removed the auto-generated socket directory. This reintroduces it in the lambda function only. I'm not at all confident that this is where you'd want this, and will be glad to modify if you have some feedback about a proper place to put it per your coding standards.
