### PR TITLE
Disallow unknown commandline arguments

### DIFF
--- a/hsds/app.py
+++ b/hsds/app.py
@@ -217,7 +217,7 @@ def main():
         help="directory for config data",
     )
 
-    args, extra_args = parser.parse_known_args()
+    args = parser.parse_args()
 
     kwargs = {}  # options to pass to hsdsapp
 


### PR DESCRIPTION
I ran into this today where I mistyped the `--config_dir` option as `--config-dir` and then spent a long time looking through my config files to work out why requests to the server weren't working. I feel it's nicer for users to be told if a commandline argument is wrong as it can be easy to make this sort of mistake. The `extra_args` variable didn't seem to be used anyway.

Thanks again for all the work on HSDS, it looks like there has been lots of development recently.