### PR TITLE
Azurefix

### DIFF
--- a/admin/config/config.yml
+++ b/admin/config/config.yml
@@ -85,7 +85,7 @@ domain_req_max_objects_limit: 500 # maximum number of objects to return in GET d
 # the following two values with give backof times of approx: 0.2, 0.4, 0.8, 1.6, 3.2, 6.4, 12.8
 dn_max_retries: 7 # number of time to retry DN requests
 dn_retry_backoff_exp: 0.1 # backoff factor for retries
-
+xss_protection: "1; mode=block"  # Include in response headers if set
 # DEPRECATED - the remaining config values are not used in currently but kept for backward compatibility with older container images
 aws_lambda_chunkread_function: null # name of aws lambda function for chunk reading
 aws_lambda_threshold: 4 # number of chunks per node per request to reach before using lambda

--- a/hsds/util/httpUtil.py
+++ b/hsds/util/httpUtil.py
@@ -480,11 +480,17 @@ async def jsonResponse(resp, data, status=200, ignore_nan=False, body_only=False
     JSON data
     """
     # tbd - remove resp parameter - not used
+    
     text = simplejson.dumps(data, ignore_nan=ignore_nan)
     if body_only:
         return text
     else:
-        return json_response(text=text, headers={}, status=status)
+        server_name = config.get("server_name")
+        xss_protection = config.get("xss_protection", default="1; mode=block")
+        headers = {"Server": server_name}
+        if xss_protection:
+            headers["X-XSS-Protection"] = xss_protection
+        return json_response(text=text, headers=headers, status=status)
 
 
 def getHref(request, uri, query=None, domain=None):

--- a/hsds/util/httpUtil.py
+++ b/hsds/util/httpUtil.py
@@ -480,7 +480,7 @@ async def jsonResponse(resp, data, status=200, ignore_nan=False, body_only=False
     JSON data
     """
     # tbd - remove resp parameter - not used
-    
+
     text = simplejson.dumps(data, ignore_nan=ignore_nan)
     if body_only:
         return text

--- a/tests/integ/uptest.py
+++ b/tests/integ/uptest.py
@@ -45,6 +45,21 @@ class UpTest(unittest.TestCase):
             rsp.headers["Access-Control-Allow-Methods"], "GET",
         )
 
+    def testResponseHeaders(self):
+        endpoint = helper.getEndpoint()
+        req = endpoint + "/about"
+        rsp = self.session.get(req)
+        self.assertEqual(rsp.status_code, 200)
+
+        self.assertTrue("X-XSS-Protection" in rsp.headers)
+        self.assertEqual(rsp.headers["X-XSS-Protection"], "1; mode=block")
+        self.assertTrue("Server" in rsp.headers)
+        server = rsp.headers["Server"]
+        server = server.lower()
+        # should see the default server value (Python with version #)
+        self.assertEqual(server.find("python"), -1)
+
+
     def testGetAbout(self):
         endpoint = helper.getEndpoint()
         req = endpoint + "/about"
@@ -53,7 +68,7 @@ class UpTest(unittest.TestCase):
         self.assertEqual(rsp.headers["Content-Type"], "application/json; charset=utf-8")
 
         rspJson = json.loads(rsp.text)
-        self.assertTrue("state") in rspJson
+        self.assertTrue("state" in rspJson)
         self.assertEqual(rspJson["state"], "READY")
         self.assertTrue("about" in rspJson)
         self.assertTrue("hsds_version" in rspJson)

--- a/tests/integ/uptest.py
+++ b/tests/integ/uptest.py
@@ -59,7 +59,6 @@ class UpTest(unittest.TestCase):
         # should see the default server value (Python with version #)
         self.assertEqual(server.find("python"), -1)
 
-
     def testGetAbout(self):
         endpoint = helper.getEndpoint()
         req = endpoint + "/about"


### PR DESCRIPTION
Security updates for header responses:
  1. Use hsds server name for "Server" key
  2. Include "X-XSS-Protection" header key if provided in config