### PR TITLE
add curl to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.9-slim AS hsds-base
 
+# Install Curl
+RUN apt-get update; apt-get -y install curl
+
 # Install HSDS
 RUN mkdir /usr/local/src/hsds/ \
     /usr/local/src/hsds/hsds/ \


### PR DESCRIPTION
Add curl to Dockerfile (needed for running on EC2 with implicit credentials)