### PR TITLE
Implement recurse until hard link by h5path

### DIFF
--- a/hsds/basenode.py
+++ b/hsds/basenode.py
@@ -33,7 +33,7 @@ from .util.authUtil import isAdminUser
 from .util.k8sClient import getDnLabelSelector, getPodIps
 from . import hsds_logger as log
 
-HSDS_VERSION = "0.7.3"
+HSDS_VERSION = "0.8.0"
 
 
 def getVersion():

--- a/hsds/ctype_sn.py
+++ b/hsds/ctype_sn.py
@@ -16,7 +16,7 @@
 
 from aiohttp.web_exceptions import HTTPBadRequest, HTTPGone
 from json import JSONDecodeError
-from .util.httpUtil import http_post, http_put, http_delete, getHref
+from .util.httpUtil import http_post, http_put, http_delete, getHref, respJsonAssemble
 from .util.httpUtil import jsonResponse
 from .util.idUtil import isValidUuid, getDataNodeUrl, createObjId
 from .util.authUtil import getUserPasswordFromRequest, aclCheck
@@ -95,7 +95,7 @@ async def GET_Datatype(request):
             group_id = domain_json["root"]
         # throws 404 if not found
         kwargs = {"bucket": bucket, "domain": domain}
-        ctype_id = await getObjectIdByPath(app, group_id, h5path, **kwargs)
+        ctype_id, domain, _ = await getObjectIdByPath(app, group_id, h5path, **kwargs)
         if not isValidUuid(ctype_id, "Datatype"):
             msg = f"No datatype exist with the path: {h5path}"
             log.warn(msg)
@@ -107,7 +107,9 @@ async def GET_Datatype(request):
     # get authoritative state for ctype from DN
     #   (even if it's in the meta_cache)
     kwargs = {"bucket": bucket, "refresh": True, "include_attrs": include_attrs}
+
     type_json = await getObjectJson(app, ctype_id, **kwargs)
+    type_json = respJsonAssemble(type_json, params, ctype_id)
     type_json["domain"] = getPathForDomain(domain)
 
     if getAlias:

--- a/hsds/domain_sn.py
+++ b/hsds/domain_sn.py
@@ -27,7 +27,7 @@ from aiohttp.client_exceptions import ClientError
 from aiohttp.web import json_response
 from requests.sessions import merge_setting
 
-from .util.httpUtil import http_post, http_put, http_get, http_delete, getHref
+from .util.httpUtil import getObjectClass, http_post, http_put, http_get, http_delete, getHref, respJsonAssemble
 from .util.httpUtil import jsonResponse
 from .util.idUtil import getDataNodeUrl, createObjId, getCollectionForId
 from .util.idUtil import isValidUuid, isSchema2Id, getNodeCount
@@ -703,6 +703,23 @@ async def GET_Domain(request):
     app = request.app
     params = request.rel_url.query
 
+    parent_id = None
+    include_links = False
+    include_attrs = False
+    follow_soft_links = False
+    follow_external_links = False
+
+    if "parent_id" in params and params["parent_id"]:
+        parent_id = params["parent_id"]
+    if "include_links" in params and params["include_links"]:
+        include_links = True
+    if "include_attrs" in params and params["include_attrs"]:
+        include_attrs = True
+    if "follow_soft_links" in params and params["follow_soft_links"]:
+        follow_soft_links = True
+    if "follow_external_links" in params and params["follow_external_links"]:
+        follow_external_links = True
+
     (username, pswd) = getUserPasswordFromRequest(request)
     if username is None and app["allow_noauth"]:
         username = "default"
@@ -766,15 +783,29 @@ async def GET_Domain(request):
         # if h5path is passed in, return object info for that path
         #   (if exists)
         h5path = params["h5path"]
-        root_id = domain_json["root"]
+
+        # select which object to perform path search under
+        root_id = parent_id if parent_id else domain_json["root"]
+
         # getObjectIdByPath throws 404 if not found
-        obj_id = await getObjectIdByPath(app, root_id, h5path, bucket=bucket, domain=domain)
+        obj_id, domain, _ = await getObjectIdByPath(
+            app, root_id, h5path, bucket=bucket, domain=domain,
+            follow_soft_links=follow_soft_links,
+            follow_external_links=follow_external_links)
         log.info(f"get obj_id: {obj_id} from h5path: {h5path}")
         # get authoritative state for object from DN (even if
         # it's in the meta_cache).
-        kwargs = {"refresh": True, "bucket": bucket}
+        kwargs = {"refresh": True, "bucket": bucket,
+                  "include_attrs": include_attrs, "include_links": include_links}
+
         obj_json = await getObjectJson(app, obj_id, **kwargs)
-        obj_json["domain"] = domain
+
+        obj_json = respJsonAssemble(obj_json, params, obj_id)
+
+        obj_json["domain"] = getPathForDomain(domain)
+
+        # client may not know class of object retrieved via path
+        obj_json["class"] = getObjectClass(obj_id)
         # Not bothering with hrefs for h5path lookups...
         resp = await jsonResponse(request, obj_json)
         log.response(request, resp=resp)
@@ -1120,6 +1151,7 @@ async def PUT_Domain(request):
         log.debug(f"new root group id: {root_id}")
         group_json = {"id": root_id, "root": root_id, "domain": domain}
         log.debug(f"create group for domain, body: {group_json}")
+
         if body and "group" in body:
             group_body = body["group"]
             if "creationProperties" in group_body:

--- a/hsds/link_sn.py
+++ b/hsds/link_sn.py
@@ -35,6 +35,7 @@ async def GET_Links(request):
     params = request.rel_url.query
 
     group_id = request.match_info.get("id")
+
     if not group_id:
         msg = "Missing group id"
         log.warn(msg)
@@ -266,6 +267,7 @@ async def PUT_Link(request):
     bucket = getBucketForDomain(domain)
     if not bucket:
         bucket = config.get("bucket_name")
+
     await validateAction(app, domain, group_id, username, "create")
 
     # for hard links, verify that the referenced id exists and is in

--- a/tests/integ/helper.py
+++ b/tests/integ/helper.py
@@ -145,7 +145,7 @@ def getDNSDomain(domain):
     return dns_domain
 
 
-def setupDomain(domain, folder=False, username=None, password=None):
+def setupDomain(domain, folder=False, username=None, password=None, root_gcpl=None):
     """Create domain (and parent domain if needed)"""
     endpoint = config.get("hsds_endpoint")
     headers = getRequestHeaders(domain=domain, username=username, password=password)
@@ -164,9 +164,14 @@ def setupDomain(domain, folder=False, username=None, password=None):
         setupDomain(parent_domain, folder=True)
 
         headers = getRequestHeaders(domain=domain)
-        body = None
+
+        body = {}
         if folder:
-            body = {"folder": True}
+            body["folder"] = True
+        if root_gcpl is not None:
+            body["group"] = {"creationProperties": root_gcpl}
+
+        if body != {}:
             rsp = session.put(req, data=json.dumps(body), headers=headers)
         else:
             rsp = session.put(req, headers=headers)


### PR DESCRIPTION
Implemented the 'recurse_until_hard' option for clients which, when used with h5path, tells the server to keep following symbolic links until it finds a hard link (e.g. an actual object). This allows a client to get any object by path in a single request.

This adds support for external link traversal in getObjectIdByPath.

This is backwards-compatible with old clients.

On the icesat2-benchmark, this decreased the time taken from ~4 seconds (with the link traversal changei n #219) to ~3.6 seconds.