### PR TITLE
Return href information for h5path requests

### DIFF
--- a/hsds/domain_sn.py
+++ b/hsds/domain_sn.py
@@ -806,7 +806,35 @@ async def GET_Domain(request):
 
         # client may not know class of object retrieved via path
         obj_json["class"] = getObjectClass(obj_id)
-        # Not bothering with hrefs for h5path lookups...
+
+        hrefs = []
+        hrefs.append({"rel": "self", "href": getHref(request, "/")})
+        if "root" in domain_json:
+            root_uuid = domain_json["root"]
+            href = getHref(request, "/datasets")
+            hrefs.append({"rel": "database", "href": href})
+            href = getHref(request, "/groups")
+            hrefs.append({"rel": "groupbase", "href": href})
+            href = getHref(request, "/datatypes")
+            hrefs.append({"rel": "typebase", "href": href})
+            href = getHref(request, "/groups/" + root_uuid)
+            hrefs.append({"rel": "root", "href": href})
+            href = getHref(request, "/")
+            hrefs.append({"rel": "home", "href": href})
+
+        hrefs.append({"rel": "acls", "href": getHref(request, "/acls")})
+        parent_domain = getParentDomain(domain)
+        if not parent_domain or getPathForDomain(parent_domain) == "/":
+            is_toplevel = True
+        else:
+            is_toplevel = False
+        log.debug(f"href parent domain: {parent_domain}")
+        if not is_toplevel:
+            href = getHref(request, "/", domain=parent_domain)
+            hrefs.append({"rel": "parent", "href": href})
+
+        obj_json["hrefs"] = hrefs
+
         resp = await jsonResponse(request, obj_json)
         log.response(request, resp=resp)
         return resp

--- a/hsds/servicenode_lib.py
+++ b/hsds/servicenode_lib.py
@@ -285,7 +285,9 @@ async def getObjectIdByPath(app, obj_id, h5path, bucket=None, refresh=False, dom
                 log.debug(msg)
                 obj_id, domain, link_json = await getObjectIdByPath(
                     app, ext_domain_json["root"], link_json["h5path"],
-                    bucket=bucket, refresh=refresh, domain=domain)
+                    bucket=bucket, refresh=refresh, domain=domain,
+                    follow_soft_links=follow_soft_links,
+                    follow_external_links=follow_external_links)
             else:
                 msg = "Cannot follow external link by relative path"
                 log.warn(msg)
@@ -303,7 +305,9 @@ async def getObjectIdByPath(app, obj_id, h5path, bucket=None, refresh=False, dom
                 # If relative path, keep parent object the same
                 obj_id, domain, link_json = await getObjectIdByPath(
                     app, obj_id, path_from_link, bucket=bucket,
-                    refresh=refresh, domain=domain)
+                    refresh=refresh, domain=domain,
+                    follow_soft_links=follow_soft_links,
+                    follow_external_links=follow_external_links)
             else:
                 if not domain:
                     msg = "Soft link with absolute path used with no domain given"
@@ -316,7 +320,9 @@ async def getObjectIdByPath(app, obj_id, h5path, bucket=None, refresh=False, dom
 
                 obj_id, domain, link_json = await getObjectIdByPath(
                     app, domain_json["root"], path_from_link,
-                    bucket=bucket, refresh=refresh, domain=domain)
+                    bucket=bucket, refresh=refresh, domain=domain,
+                    follow_soft_links=follow_soft_links,
+                    follow_external_links=follow_external_links)
 
         elif link_json["class"] == "H5L_TYPE_HARD":
             obj_id = link_json["id"]
@@ -356,7 +362,9 @@ async def getObjectIdByPath(app, obj_id, h5path, bucket=None, refresh=False, dom
 
         obj_id, domain, link_json = await getObjectIdByPath(
             app, parent_id, link_json["h5path"],
-            bucket=bucket, refresh=refresh, domain=domain)
+            bucket=bucket, refresh=refresh, domain=domain,
+            follow_soft_links=follow_soft_links,
+            follow_external_links=follow_external_links)
 
     return obj_id, domain, link_json
 


### PR DESCRIPTION
This is useful for H5Ovisit in the REST VOL.

Also fix `getObjectIdByPath` not passing the values of `follow_soft_links` and `follow_external_links` to recursive calls of itself.