### PR TITLE
Fix jsonToArray error on empty data read

### DIFF
--- a/hsds/util/arrayUtil.py
+++ b/hsds/util/arrayUtil.py
@@ -194,7 +194,7 @@ def jsonToArray(data_shape, data_dtype, data_json):
         if arr.shape != data_shape:
             arr = arr.reshape(data_shape)  # reshape to match selection
     else:
-        arr = np.array([], dtype=data_dtype)
+        arr = np.array([]).astype(data_dtype)
 
     return arr
 

--- a/hsds/util/arrayUtil.py
+++ b/hsds/util/arrayUtil.py
@@ -174,24 +174,27 @@ def jsonToArray(data_shape, data_dtype, data_json):
             data_json,
         ]  # listify
 
-    if isVlen(data_dtype):
-        arr = np.zeros((npoints,), dtype=data_dtype)
-        fillVlenArray(np_shape_rank, data_json, arr, 0)
+    if not (None in data_json):
+        if isVlen(data_dtype):
+            arr = np.zeros((npoints,), dtype=data_dtype)
+            fillVlenArray(np_shape_rank, data_json, arr, 0)
+        else:
+            try:
+                arr = np.array(data_json, dtype=data_dtype)
+            except UnicodeEncodeError as ude:
+                msg = "Unable to encode data"
+                raise ValueError(msg) from ude
+        # raise an exception of the array shape doesn't match the selection shape
+        # allow if the array is a scalar and the selection shape is one element,
+        # numpy is ok with this
+        if arr.size != npoints:
+            msg = "Input data doesn't match selection number of elements"
+            msg += f" Expected {npoints}, but received: {arr.size}"
+            raise ValueError(msg)
+        if arr.shape != data_shape:
+            arr = arr.reshape(data_shape)  # reshape to match selection
     else:
-        try:
-            arr = np.array(data_json, dtype=data_dtype)
-        except UnicodeEncodeError as ude:
-            msg = "Unable to encode data"
-            raise ValueError(msg) from ude
-    # raise an exception of the array shape doesn't match the selection shape
-    # allow if the array is a scalar and the selection shape is one element,
-    # numpy is ok with this
-    if arr.size != npoints:
-        msg = "Input data doesn't match selection number of elements"
-        msg += f" Expected {npoints}, but received: {arr.size}"
-        raise ValueError(msg)
-    if arr.shape != data_shape:
-        arr = arr.reshape(data_shape)  # reshape to match selection
+        arr = np.array([], dtype=data_dtype)
 
     return arr
 

--- a/tests/unit/array_util_test.py
+++ b/tests/unit/array_util_test.py
@@ -696,6 +696,20 @@ class ArrayUtilTest(unittest.TestCase):
             cnt += 1
         self.assertEqual(cnt, 20)
 
+    def testJsonToArrayOnNoneArray(self):
+        data_dtype = np.dtype("i4")
+        data_shape = [0, ]
+        data_json = [None]
+        arr = None
+
+        try:
+            arr = jsonToArray(data_shape, data_dtype, data_json)
+        except Exception as e:
+            print(f"Exception while testing jsonToArray on array with None elements: {e}")
+
+        self.assertTrue(len(arr) == 0)
+        self.assertTrue(arr.dtype == data_dtype)
+
 
 if __name__ == "__main__":
     # setup test files


### PR DESCRIPTION
This lets clients read from an empty attribute without causing an internal server error.

Previously, a value in `data_json` being `None` caused errors when passed to `np.array`.