### PR TITLE
add runall.sh option for sn_cores

### DIFF
--- a/admin/docker/docker-compose-internal-lb.yml
+++ b/admin/docker/docker-compose-internal-lb.yml
@@ -5,8 +5,8 @@ services:
     restart: ${RESTART_POLICY}
     mem_limit: ${HEAD_RAM}
     environment:
-      - TARGET_SN_COUNT=${CORES}
-      - TARGET_DN_COUNT=${CORES}
+      - TARGET_SN_COUNT=${SN_CORES}
+      - TARGET_DN_COUNT=${DN_CORES}
       - NODE_TYPE=head_node
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
@@ -49,7 +49,7 @@ services:
       - HSDS_ENDPOINT=${HSDS_ENDPOINT}
 
     ports:
-      - ${SN_PORT}:${SN_PORT}
+      - ${SN_PORT_RANGE}:${SN_PORT}
     logging:
      options:
         max-size: "5k"

--- a/admin/docker/docker-compose.aws.yml
+++ b/admin/docker/docker-compose.aws.yml
@@ -55,7 +55,7 @@ services:
       - LOG_LEVEL=${LOG_LEVEL}
       - HSDS_ENDPOINT=${HSDS_ENDPOINT}
     ports:
-      - ${SN_PORT}:${SN_PORT}
+      - ${SN_PORT_RANGE}:${SN_PORT}
     depends_on:
       - head
     volumes:

--- a/admin/docker/docker-compose.azure.yml
+++ b/admin/docker/docker-compose.azure.yml
@@ -46,7 +46,7 @@ services:
       - LOG_LEVEL=${LOG_LEVEL}
       - HSDS_ENDPOINT=${HSDS_ENDPOINT}
     ports:
-      - ${SN_PORT}:${SN_PORT}
+      - ${SN_PORT_RANGE}:${SN_PORT}
     depends_on:
       - head
     volumes:

--- a/admin/docker/docker-compose.posix.yml
+++ b/admin/docker/docker-compose.posix.yml
@@ -44,7 +44,7 @@ services:
       - BUCKET_NAME=${BUCKET_NAME}
       - HSDS_ENDPOINT=${HSDS_ENDPOINT}
     ports:
-      - ${SN_PORT}:${SN_PORT}
+      - ${SN_PORT_RANGE}:${SN_PORT}
     depends_on:
       - head
     volumes:

--- a/admin/docker/docker-compose.yml
+++ b/admin/docker/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       - LOG_LEVEL=${LOG_LEVEL}
       - HSDS_ENDPOINT=${HSDS_ENDPOINT}
     ports:
-      - ${SN_PORT}:${SN_PORT}
+      - ${SN_PORT_RANGE}:${SN_PORT}
     depends_on:
       - head
     volumes:


### PR DESCRIPTION
added  optional argument to runall.sh (see runall.sh --help)  to create mutliple sn containers.