### PR TITLE
Allow n-bit and scale offset filters in DCPL

### DIFF
--- a/hsds/util/dsetUtil.py
+++ b/hsds/util/dsetUtil.py
@@ -34,7 +34,7 @@ FILTER_DEFS = (
     ("H5Z_FILTER_FLETCHER32", 3, "fletcher32"),
     ("H5Z_FILTER_SZIP", 4, "szip"),
     ("H5Z_FILTER_NBIT", 5, "nbit"),
-    ("H5Z_FILTER_SCALEOFFSET", 6, "scaleoffet"),
+    ("H5Z_FILTER_SCALEOFFSET", 6, "scaleoffset"),
     ("H5Z_FILTER_LZF", 32000, "lzf"),
     ("H5Z_FILTER_BLOSC", 32001, "blosclz"),
     ("H5Z_FILTER_SNAPPY", 32003, "snappy"),

--- a/hsds/util/storUtil.py
+++ b/hsds/util/storUtil.py
@@ -72,6 +72,8 @@ def getSupportedFilters(include_compressors=True):
         "bitshuffle",
         "shuffle",
         "fletcher32",
+        "nbit",        # No-op
+        "scaleoffset"  # No-op
     ]
     if include_compressors:
         filters.extend(getCompressors())

--- a/tests/integ/dataset_test.py
+++ b/tests/integ/dataset_test.py
@@ -1319,7 +1319,7 @@ class DatasetTest(unittest.TestCase):
         rspJson = json.loads(rsp.text)
         self.assertTrue("root" in rspJson)
 
-        bad_compressors = ("shrink-o-rama", "scaleoffet")
+        bad_compressors = ("shrink-o-rama")
         for compressor_name in bad_compressors:
             # create the dataset
             req = self.endpoint + "/datasets"


### PR DESCRIPTION
Allows n-bit and scale offset filters to be specified in the DCPL, without actually implementing the filters themselves.

Also fixes the typo for the filter name `scaleoffet -> scaleoffset`

Resolves #285