### PR TITLE
Support creation of array/nested array types

### DIFF
--- a/hsds/chunk_crawl.py
+++ b/hsds/chunk_crawl.py
@@ -67,7 +67,7 @@ def getFillValue(dset_json):
         arr = np.empty((1,), dtype=dt, order="C")
         arr[...] = fill_value
     else:
-        arr = np.zeros([1,], dtype=dt, order="C")
+        arr = None
 
     return arr
 
@@ -448,7 +448,7 @@ async def read_point_sel(
 
     def defaultArray():
         # no data, return zero array
-        if fill_value:
+        if fill_value is not None:
             arr = np.empty((num_points,), dtype=dt)
             arr[...] = fill_value
         else:

--- a/hsds/datanode_lib.py
+++ b/hsds/datanode_lib.py
@@ -1123,7 +1123,7 @@ async def get_chunk(
                 # normal fill value based init or initializer failed
                 fill_value = getFillValue(dset_json)
 
-                if fill_value:
+                if fill_value is not None:
                     chunk_arr = np.empty(dims, dtype=dt, order="C")
                     chunk_arr[...] = fill_value
                 else:

--- a/hsds/dset_lib.py
+++ b/hsds/dset_lib.py
@@ -61,7 +61,7 @@ def getFillValue(dset_json):
         arr = np.empty((1,), dtype=dt, order="C")
         arr[...] = fill_value
     else:
-        arr = np.zeros([1,], dtype=dt, order="C")
+        arr = None
 
     return arr
 
@@ -526,7 +526,7 @@ async def doReadSelection(
         # initialize to fill_value if specified
         fill_value = getFillValue(dset_json)
 
-        if fill_value:
+        if fill_value is not None:
             arr = np.empty(np_shape, dtype=dset_dtype, order="C")
             arr[...] = fill_value
         else:
@@ -712,6 +712,12 @@ async def reduceShape(app, dset_json, shape_update, bucket=None):
 
     # get the fill value
     arr = getFillValue(dset_json)
+
+    type_json = dset_json["type"]
+    dt = createDataType(type_json)
+
+    if arr is None:
+        arr = np.zeros([1], dtype=dt, order="C")
 
     # and the chunk layout
     layout = tuple(getChunkLayout(dset_json))

--- a/hsds/util/hdf5dtype.py
+++ b/hsds/util/hdf5dtype.py
@@ -662,9 +662,9 @@ def createBaseDataType(typeItem):
         if isinstance(arrayBaseType, dict):
             if "class" not in arrayBaseType:
                 raise KeyError("'class' not provided for array base type")
-            type_classes = ("H5T_INTEGER", "H5T_FLOAT", "H5T_STRING")
+            type_classes = ("H5T_INTEGER", "H5T_FLOAT", "H5T_STRING", "H5T_ARRAY")
             if arrayBaseType["class"] not in type_classes:
-                msg = "Array Type base type must be integer, float, or string"
+                msg = "Array Type base type must be integer, float, string, or array"
                 raise TypeError(msg)
         baseType = createDataType(arrayBaseType)
         metadata = None


### PR DESCRIPTION
Reading and writing to array/nested array type objects is still buggy, but this is a step in the right direction.

Previously, the check on the return value of getFillValue would throw an error when the datatype was H5T_ARRAY.