### PR TITLE
Fieldop

### DIFF
--- a/hsds/basenode.py
+++ b/hsds/basenode.py
@@ -33,7 +33,7 @@ from .util.authUtil import isAdminUser
 from .util.k8sClient import getDnLabelSelector, getPodIps
 from . import hsds_logger as log
 
-HSDS_VERSION = "0.8.4"
+HSDS_VERSION = "0.8.5"
 
 
 def getVersion():

--- a/hsds/chunk_crawl.py
+++ b/hsds/chunk_crawl.py
@@ -776,9 +776,9 @@ class ChunkCrawler:
                         bucket=self._bucket,
                         client=client,
                     )
-                    log.debug(
-                        f"write_chunk_hyperslab - got 200 status for chunk_id: {chunk_id}"
-                    )
+
+                    msg = f"write_chunk_hyperslab - got 200 status for chunk_id: {chunk_id}"
+                    log.debug(msg)
                     status_code = 200
                 elif self._action == "read_point_sel":
                     if not isinstance(self._points, dict):
@@ -786,9 +786,9 @@ class ChunkCrawler:
                         status_code = 500
                         break
                     if chunk_id not in self._points:
-                        log.error(
-                            f"ChunkCrawler - read_point_sel, no entry for chunk: {chunk_id}"
-                        )
+                        msg = "ChunkCrawler - read_point_sel, "
+                        msg += f"no entry for chunk: {chunk_id}"
+                        log.error(msg)
                         status_code = 500
                         break
                     item = self._points[chunk_id]
@@ -806,9 +806,8 @@ class ChunkCrawler:
                         bucket=self._bucket,
                         client=client,
                     )
-                    log.debug(
-                        f"read_point_sel - got 200 status for chunk_id: {chunk_id}"
-                    )
+                    msg = f"read_point_sel - got 200 status for chunk_id: {chunk_id}"
+                    log.debug(msg)
                     status_code = 200
                 elif self._action == "write_point_sel":
                     if not isinstance(self._points, dict):
@@ -816,9 +815,9 @@ class ChunkCrawler:
                         status_code = 500
                         break
                     if chunk_id not in self._points:
-                        log.error(
-                            f"ChunkCrawler - read_point_sel, no entry for chunk: {chunk_id}"
-                        )
+                        msg = "ChunkCrawler - read_point_sel, "
+                        msg += f"no entry for chunk: {chunk_id}"
+                        log.error(msg)
                         status_code = 500
                         break
                     item = self._points[chunk_id]
@@ -835,9 +834,8 @@ class ChunkCrawler:
                         bucket=self._bucket,
                         client=client,
                     )
-                    log.debug(
-                        f"read_point_sel - got 200 status for chunk_id: {chunk_id}"
-                    )
+                    msg = f"read_point_sel - got 200 status for chunk_id: {chunk_id}"
+                    log.debug(msg)
                     status_code = 200
                 else:
                     log.error(f"ChunkCrawler - unexpected action: {self._action}")
@@ -846,9 +844,8 @@ class ChunkCrawler:
 
             except ClientError as ce:
                 status_code = 500
-                log.warn(
-                    f"ClientError {type(ce)} for {self._action}({chunk_id}): {ce} "
-                )
+                msg = f"ClientError {type(ce)} for {self._action}({chunk_id}): {ce} "
+                log.warn(msg)
             except CancelledError as cle:
                 status_code = 503
                 log.warn(f"CancelledError for {self._action}({chunk_id}): {cle}")
@@ -861,9 +858,8 @@ class ChunkCrawler:
                 break
             except HTTPInternalServerError as ise:
                 status_code = 500
-                log.warn(
-                    f"HTTPInternalServerError for {self._action}({chunk_id}): {ise}"
-                )
+                msg = f"HTTPInternalServerError for {self._action}({chunk_id}): {ise}"
+                log.warn(msg)
             except HTTPServiceUnavailable as sue:
                 status_code = 503
                 msg = f"HTTPServiceUnavailable for {self._action}({chunk_id}): {sue}"

--- a/hsds/chunk_dn.py
+++ b/hsds/chunk_dn.py
@@ -423,9 +423,10 @@ async def GET_Chunk(request):
     log.debug(f"GET_Chunk - got selection: {selection}")
 
     if "fields" in params:
-        select_fields = params["fields"].split(",")
+        select_fields = params["fields"].split(":")
+        log.debug(f"GET_Chunk - got fields: {select_fields}")
     else:
-        select_fields = [] 
+        select_fields = []
 
     if getChunkInitializer(dset_json):
         chunk_init = True
@@ -452,7 +453,7 @@ async def GET_Chunk(request):
 
     if chunk_init:
         save_chunk(app, chunk_id, dset_json, chunk_arr, bucket=bucket)
-     
+
     if query:
         try:
             parser = BooleanParser(query)

--- a/hsds/chunk_dn.py
+++ b/hsds/chunk_dn.py
@@ -422,6 +422,11 @@ async def GET_Chunk(request):
         raise HTTPInternalServerError()
     log.debug(f"GET_Chunk - got selection: {selection}")
 
+    if "fields" in params:
+        select_fields = params["fields"].split(",")
+    else:
+        select_fields = [] 
+
     if getChunkInitializer(dset_json):
         chunk_init = True
     else:
@@ -447,9 +452,8 @@ async def GET_Chunk(request):
 
     if chunk_init:
         save_chunk(app, chunk_id, dset_json, chunk_arr, bucket=bucket)
-
+     
     if query:
-
         try:
             parser = BooleanParser(query)
         except Exception as e:
@@ -488,7 +492,7 @@ async def GET_Chunk(request):
             raise HTTPNotFound()
     else:
         # read selected data from chunk
-        output_arr = chunkReadSelection(chunk_arr, slices=selection)
+        output_arr = chunkReadSelection(chunk_arr, slices=selection, fields=select_fields)
 
     # write response
     if output_arr is not None:

--- a/hsds/chunk_sn.py
+++ b/hsds/chunk_sn.py
@@ -74,6 +74,7 @@ def use_http_streaming(request, rank):
         return False
     return True
 
+
 def _isAppend(params, body=None):
     """ return True if append values are specified in params or body """
     if isinstance(body, dict) and "append" in body and body["append"]:
@@ -90,7 +91,7 @@ def _getAppendDim(params, body=None):
     if isinstance(body, dict):
         if "append_dim" in body:
             append_dim_param = body["append_dim"]
-           
+
     if append_dim_param is None:
         # check query param
         if "append_dim" in params:
@@ -113,7 +114,7 @@ def _getAppendDim(params, body=None):
 def _getAppendRows(params, dset_json, body=None):
     """ get append rows value from query param or body """
     append_rows = None
-    
+
     if isinstance(body, dict) and "append" in body and body["append"]:
         try:
             append_rows = int(body["append"])
@@ -121,7 +122,7 @@ def _getAppendRows(params, dset_json, body=None):
             msg = "invalid append value in body"
             log.warn(msg)
             raise HTTPBadRequest(reason=msg)
-    elif "append" in params  and params["append"]:
+    elif "append" in params and params["append"]:
         try:
             append_rows = int(params["append"])
         except ValueError:
@@ -160,7 +161,7 @@ def _getAppendRows(params, dset_json, body=None):
             msg = "invalid append_dim"
             log.warn(msg)
             raise HTTPBadRequest(reason=msg)
-        
+
         if maxdims[append_dim] != 0:
             if dims[append_dim] + append_rows > maxdims[append_dim]:
                 log.warn("unable to append to dataspace")
@@ -168,17 +169,19 @@ def _getAppendRows(params, dset_json, body=None):
 
     return append_rows
 
+
 def _isSelect(params, body=None):
     """ return True if select param or select is set in request body
     """
     if "select" in params and params["select"]:
         return True
-          
+
     if isinstance(body, dict):
         for key in ("start", "stop", "step"):
             if key in body and body[key]:
                 return True
     return False
+
 
 def _getSelect(params, dset_json, body=None):
     """ return selection region if any as a list
@@ -187,7 +190,7 @@ def _getSelect(params, dset_json, body=None):
     try:
         if body and "start" in body and "stop" in body:
             slices = get_slices(body, dset_json)
-        else: 
+        else:
             select = params.get("select")
             slices = get_slices(select, dset_json)
     except ValueError as ve:
@@ -200,7 +203,7 @@ def _getSelect(params, dset_json, body=None):
         raise HTTPBadRequest(reason=msg)
 
     return slices
-    
+
 
 def _getSelectDtype(params, dset_dtype, body=None):
     """ if a field list is defined in params or body,
@@ -222,12 +225,13 @@ def _getSelectDtype(params, dset_dtype, body=None):
         except TypeError as te:
             msg = f"invalid fields selection: {te}"
             log.warn(msg)
-            raise HTTPBadRequest(reason=msg)   
+            raise HTTPBadRequest(reason=msg)
         log.debug(f"using select dtype: {select_dtype}")
     else:
         select_dtype = dset_dtype  # return all fields
-    
+
     return select_dtype
+
 
 def _getLimit(params, body=None):
     if isinstance(body, dict) and "Limit" in body:
@@ -269,6 +273,7 @@ def _getPoints(body, rank=1):
         raise HTTPBadRequest(reason=msg)
     return points
 
+
 def _getQuery(params, dtype, rank=1, body=None):
     if "query" in params:
         query = params["query"]
@@ -292,8 +297,9 @@ def _getQuery(params, dtype, rank=1, body=None):
             log.warn(msg)
 
         # following will throw HTTPBadRequest if query is malformed
-        getParser(query, dtype)  
+        getParser(query, dtype)
     return query
+
 
 def _getElementCount(params, body=None):
     """ get element count as query param or body key """
@@ -314,11 +320,12 @@ def _getElementCount(params, body=None):
         log.debug(f"element_count body: {element_count}")
     else:
         element_count = None
-    
+
     return element_count
 
+
 async def _getRequestData(request, http_streaming=True):
-    """ get input data from request 
+    """ get input data from request
         return dict for json input, bytes for non-streaming binary
         or None, for streaming """
 
@@ -368,6 +375,7 @@ async def _getRequestData(request, http_streaming=True):
                 raise  # re-throw
     return input_data
 
+
 async def arrayResponse(arr, request, dset_json):
     """ return the array as binary or json response based on accept type """
     response_type = getAcceptType(request)
@@ -402,16 +410,18 @@ async def arrayResponse(arr, request, dset_json):
             raise HTTPBadRequest(reason=msg)
         rsp_json["value"] = json_query_data
         rsp_json["hrefs"] = get_hrefs(request, dset_json)
-        
+
         resp = await jsonResponse(request, rsp_json)
     return resp
 
-async def _doPointWrite(app, request,
-    points=None,
-    data=None,
-    dset_json=None,
-    bucket=None
-):
+
+async def _doPointWrite(app,
+                        request,
+                        points=None,
+                        data=None,
+                        dset_json=None,
+                        bucket=None
+                        ):
     """ write the given points to the dataset """
 
     num_points = len(points)
@@ -419,7 +429,7 @@ async def _doPointWrite(app, request,
     dset_id = dset_json["id"]
     layout = getChunkLayout(dset_json)
     datashape = dset_json["shape"]
-    dims = getShapeDims(datashape)  
+    dims = getShapeDims(datashape)
     rank = len(dims)
 
     chunk_dict = {}  # chunk ids to list of points in chunk
@@ -493,14 +503,15 @@ async def _doPointWrite(app, request,
         log.info("doPointWrite success")
 
 
-async def _doHyperslabWrite(app, request, 
-    page_number=0, 
-    page=None, 
-    data=None,
-    dset_json=None,
-    select_dtype=None,
-    bucket=None
-):
+async def _doHyperslabWrite(app,
+                            request,
+                            page_number=0,
+                            page=None,
+                            data=None,
+                            dset_json=None,
+                            select_dtype=None,
+                            bucket=None
+                            ):
     """ write the given page selection to the dataset """
     dset_id = dset_json["id"]
     log.info(f"_doHyperslabWrite on {dset_id} - page: {page_number}")
@@ -541,7 +552,7 @@ async def _doHyperslabWrite(app, request,
             raise HTTPBadRequest(reason=msg)
     else:
         arr = data  # use array provided to function
-    
+
     try:
         chunk_ids = getChunkIds(dset_id, page, layout)
     except ValueError:
@@ -586,7 +597,7 @@ async def PUT_Value(request):
     num_elements = None
     element_count = None
     limit = None  # query limit
-    
+
     arr_rsp = None  # array data to return if any
 
     if not request.has_body:
@@ -670,7 +681,7 @@ async def PUT_Value(request):
     query = _getQuery(params, dset_dtype, rank=rank, body=body)
 
     element_count = _getElementCount(params, body=body)
-    
+
     if item_size == 'H5T_VARIABLE' or element_count or not use_http_streaming(request, rank):
         http_streaming = False
     else:
@@ -695,7 +706,7 @@ async def PUT_Value(request):
         resp = await arrayResponse(arr_rsp, request, dset_json)
         log.response(request, resp=resp)
         return resp
-    
+
     # regular PUT_Value processing without query update
     binary_data = None
     np_shape = []  # shape of incoming data
@@ -703,7 +714,7 @@ async def PUT_Value(request):
     input_data = await _getRequestData(request, http_streaming=http_streaming)
     # could be int, list, str, bytes, or  None
     log.debug(f"got input data type: {type(input_data)}")
-    
+
     if append_rows:
         # extend datashape and set slices to shape of appended region
         # make sure any other dimensions are non-zero
@@ -864,14 +875,14 @@ async def PUT_Value(request):
                 kwargs["data"] = arr
             else:
                 kwargs["data"] = None
-            # do write for one page selection  
+            # do write for one page selection
             await _doHyperslabWrite(app, request, **kwargs)
     else:
         #
         # Do point put
         #
         kwargs = {"points": points, "data": arr, "dset_json": dset_json, "bucket": bucket}
-        await _doPointWrite(app, request, **kwargs)    
+        await _doPointWrite(app, request, **kwargs)
 
     # write successful
 
@@ -936,7 +947,7 @@ async def GET_Value(request):
 
     # Get query parameter for selection
     slices = _getSelect(params, dset_json)
-     
+
     fields_param = params.get("fields")
     if fields_param:
         log.debug(f"fields param: {fields_param}")
@@ -954,7 +965,7 @@ async def GET_Value(request):
     log.debug(f"dset_dtype: {dset_dtype}, select_dtype: {select_dtype}")
 
     limit = _getLimit(params)
-     
+
     if "ignore_nan" in params and params["ignore_nan"]:
         ignore_nan = True
     else:

--- a/hsds/chunk_sn.py
+++ b/hsds/chunk_sn.py
@@ -819,7 +819,7 @@ async def GET_Value(request):
     fields_param = params.get("fields")
     if fields_param:
         log.debug(f"fields param: {fields_param}")
-        select_fields = [fields_param,]  # tbd, process multiple field names
+        select_fields = fields_param.split(":")
         if select_fields:
             if len(dset_dtype) == 0:
                 msg = "fields query parameter can only be used with compound type datasets"
@@ -1010,6 +1010,7 @@ async def GET_Value(request):
                 dset_id,
                 dset_json,
                 slices,
+                select_dtype=select_dtype,
                 query=query,
                 bucket=bucket,
                 limit=limit,

--- a/hsds/chunk_sn.py
+++ b/hsds/chunk_sn.py
@@ -599,7 +599,10 @@ async def _doHyperslabWrite(app,
     except ValueError:
         log.warn("getChunkIds failed")
         raise HTTPInternalServerError()
-    log.debug(f"chunk_ids: {chunk_ids}")
+    if len(chunk_ids) < 10:
+        log.debug(f"chunk_ids: {chunk_ids}")
+    else:
+        log.debug(f"chunk_ids: {chunk_ids[:10]} ...")
     if len(chunk_ids) > max_chunks:
         msg = f"got {len(chunk_ids)} for page: {page_number}.  max_chunks: {max_chunks}"
         log.warn(msg)

--- a/hsds/dset_dn.py
+++ b/hsds/dset_dn.py
@@ -206,7 +206,7 @@ async def PUT_DatasetShape(request):
     dset_id = request.match_info.get("id")
 
     if not isValidUuid(dset_id, obj_class="dataset"):
-        log.error("Unexpected type_id: {}".format(dset_id))
+        log.error(f"Unexpected dset_id: {dset_id}")
         raise HTTPInternalServerError()
 
     body = await request.json()

--- a/hsds/dset_lib.py
+++ b/hsds/dset_lib.py
@@ -579,8 +579,6 @@ async def doReadSelection(
         log.info(msg)
         raise HTTPInternalServerError()
 
-    log.debug(f"ret arr: f{arr}")
-
     if query is not None:
         # combine chunk responses and return
         if limit > 0 and crawler._hits > limit:

--- a/hsds/dset_lib.py
+++ b/hsds/dset_lib.py
@@ -317,7 +317,7 @@ def get_chunkmap_selections(chunk_map, chunk_ids, slices, dset_json):
     """Update chunk_map with chunk and data selections for the
     given set of slices
     """
-    log.debug(f"get_chunkmap_selections - chunk_ids: {chunk_ids}")
+    log.debug(f"get_chunkmap_selections - {len(chunk_ids)} chunk_ids")
     if not slices:
         log.debug("no slices set, returning")
         return  # nothing to do
@@ -344,7 +344,7 @@ def get_chunk_selections(chunk_map, chunk_ids, slices, dset_json):
     """Update chunk_map with chunk and data selections for the
     given set of slices
     """
-    log.debug(f"get_chunk_selections - chunk_ids: {chunk_ids}")
+    log.debug(f"get_chunk_selections - {len(chunk_ids)} chunk_ids")
     if not slices:
         log.debug("no slices set, returning")
         return  # nothing to do
@@ -358,9 +358,8 @@ def get_chunk_selections(chunk_map, chunk_ids, slices, dset_json):
             chunk_map[chunk_id] = item
 
         chunk_sel = getChunkCoverage(chunk_id, slices, layout)
-        log.debug(
-            f"get_chunk_selections - chunk_id: {chunk_id}, chunk_sel: {chunk_sel}"
-        )
+        msg = f"get_chunk_selections - chunk_id: {chunk_id}, chunk_sel: {chunk_sel}"
+        log.debug(msg)
         item["chunk_sel"] = chunk_sel
         data_sel = getDataCoverage(chunk_id, slices, layout)
         log.debug(f"get_chunk_selections - data_sel: {data_sel}")
@@ -493,7 +492,10 @@ async def doReadSelection(
 ):
     """read selection utility function"""
     log.info(f"doReadSelection - number of chunk_ids: {len(chunk_ids)}")
-    log.debug(f"doReadSelection - chunk_ids: {chunk_ids}")
+    if len(chunk_ids) < 10:
+        log.debug(f"chunk_ids: {chunk_ids}")
+    else:
+        log.debug(f"chunk_ids: {chunk_ids[:10]} ...")
     log.debug(f"doReadSelection - select_dtype: {select_dtype}")
 
     type_json = dset_json["type"]

--- a/hsds/dset_lib.py
+++ b/hsds/dset_lib.py
@@ -376,6 +376,7 @@ async def getSelectionData(
     dset_id,
     dset_json,
     slices=None,
+    select_dtype=None,
     points=None,
     query=None,
     query_update=None,
@@ -452,6 +453,7 @@ async def getSelectionData(
         chunk_ids,
         dset_json,
         slices=slices,
+        select_dtype=select_dtype,
         points=points,
         query=query,
         query_update=query_update,
@@ -468,6 +470,7 @@ async def doReadSelection(
     chunk_ids,
     dset_json,
     slices=None,
+    select_dtype=None,
     points=None,
     query=None,
     query_update=None,
@@ -478,11 +481,14 @@ async def doReadSelection(
     """read selection utility function"""
     log.info(f"doReadSelection - number of chunk_ids: {len(chunk_ids)}")
     log.debug(f"doReadSelection - chunk_ids: {chunk_ids}")
+    log.debug(f"doReadSelection - select_dtype: {select_dtype}")
 
     type_json = dset_json["type"]
     item_size = getItemSize(type_json)
     log.debug(f"item size: {item_size}")
     dset_dtype = createDataType(type_json)  # np datatype
+    if select_dtype is None:
+        select_dtype = dset_dtype
     if query is None:
         query_dtype = None
     else:
@@ -494,9 +500,7 @@ async def doReadSelection(
 
     if points is not None:
         # point selection
-        np_shape = [
-            len(points),
-        ]
+        np_shape = [len(points), ]
     elif query is not None:
         # return shape will be determined by number of matches
         np_shape = None
@@ -527,10 +531,10 @@ async def doReadSelection(
         fill_value = getFillValue(dset_json)
 
         if fill_value is not None:
-            arr = np.empty(np_shape, dtype=dset_dtype, order="C")
+            arr = np.empty(np_shape, dtype=select_dtype, order="C")
             arr[...] = fill_value
         else:
-            arr = np.zeros(np_shape, dtype=dset_dtype, order="C")
+            arr = np.zeros(np_shape, dtype=select_dtype, order="C")
 
     crawler = ChunkCrawler(
         app,

--- a/hsds/dset_lib.py
+++ b/hsds/dset_lib.py
@@ -391,7 +391,7 @@ def getParser(query, dtype):
             raise HTTPBadRequest(reason=msg)
 
     return parser
-    
+
 
 async def getSelectionData(
     app,
@@ -716,6 +716,7 @@ async def getAllocatedChunkIds(app, dset_id, bucket=None):
     log.debug(f"getAllocattedChunkIds - got {len(chunk_ids)} ids")
     return chunk_ids
 
+
 async def extendShape(app, dset_json, nelements, axis=0, bucket=None):
     """ extend the shape of the dataset by nelements along given axis """
     dset_id = dset_json["id"]
@@ -785,7 +786,7 @@ async def extendShape(app, dset_json, nelements, axis=0, bucket=None):
 
     log.debug(f"extendShape returning slices: {slices}")
     return slices
-            
+
 
 async def reduceShape(app, dset_json, shape_update, bucket=None):
     """ Given an existing dataset and a new shape,

--- a/hsds/dset_lib.py
+++ b/hsds/dset_lib.py
@@ -558,10 +558,11 @@ async def doReadSelection(
         log.info(f"doReadSelection raising BadRequest error:  {crawler_status}")
         raise HTTPBadRequest()
     if crawler_status not in (200, 201):
-        log.info(
-            f"doReadSelection raising HTTPInternalServerError for status:  {crawler_status}"
-        )
+        msg = f"doReadSelection raising HTTPInternalServerError for status:  {crawler_status}"
+        log.info(msg)
         raise HTTPInternalServerError()
+
+    log.debug(f"ret arr: f{arr}")
 
     if query is not None:
         # combine chunk responses and return

--- a/hsds/hsds_logger.py
+++ b/hsds/hsds_logger.py
@@ -158,6 +158,8 @@ def request(req):
         if max_task_count and active_tasks > max_task_count:
             warning(f"more than {max_task_count} tasks, returning 503")
             raise HTTPServiceUnavailable()
+        else:
+            debug(f"active_tasks: {active_tasks} max_tasks: {max_task_count}")
 
 
 def response(req, resp=None, code=None, message=None):
@@ -178,9 +180,28 @@ def response(req, resp=None, code=None, message=None):
 
     log_level = config["log_level"]
 
-    if log_level <= level:
+    if log_level == DEBUG:
         prefix = config["prefix"]
         ts = _timestamp()
 
+        num_tasks = len(asyncio.all_tasks())
+        active_tasks = _activeTaskCount()
+
+        debug(f"rsp - num tasks: {num_tasks} active tasks: {active_tasks}")
+
         s = "{}{} RSP> <{}> ({}): {}"
         print(s.format(prefix, ts, code, message, req.path))
+
+    elif log_level <= level:
+        prefix = config["prefix"]
+        ts = _timestamp()
+
+        num_tasks = len(asyncio.all_tasks())
+        active_tasks = _activeTaskCount()
+
+        debug(f"num tasks: {num_tasks} active tasks: {active_tasks}")
+
+        s = "{}{} RSP> <{}> ({}): {}"
+        print(s.format(prefix, ts, code, message, req.path))
+    else:
+        pass

--- a/hsds/util/chunkUtil.py
+++ b/hsds/util/chunkUtil.py
@@ -747,7 +747,7 @@ class ChunkIterator:
         return chunk_id
 
 
-def chunkReadSelection(chunk_arr, slices=None):
+def chunkReadSelection(chunk_arr, slices=None, fields=None):
     """
     Return data from requested chunk and selection
     """
@@ -772,6 +772,25 @@ def chunkReadSelection(chunk_arr, slices=None):
 
     # get requested data
     output_arr = chunk_arr[slices]
+
+    if fields:
+        dtype_items = []
+        if len(fields) > 1:
+            for field in fields:
+                dtype_items.append((field, chunk_arr.dtype[field]))
+            select_dtype = np.dtype(dtype_items)
+        else:
+            # don't need a compound type
+            select_dtype = chunk_arr.dtype[fields[0]]
+        # create an array with just the given fields
+        arr = np.zeros(chunk_arr.shape, select_dtype)
+        # slot in each of the given fields
+        if len(fields) > 1:
+            for field in fields:
+                arr[field] = output_arr[field]
+        else:
+            arr[...] = output_arr[fields[0]]
+        output_arr = arr  # return this
 
     return output_arr
 

--- a/hsds/util/chunkUtil.py
+++ b/hsds/util/chunkUtil.py
@@ -491,9 +491,7 @@ def getChunkIds(dset_id, selection, layout, dim=0, prefix=None, chunk_ids=None):
                     chunk_ids.append(chunk_id)
                 else:
                     chunk_id += "_"  # dimension seperator
-                    getChunkIds(
-                        dset_id, selection, layout, dim + 1, chunk_id, chunk_ids
-                    )
+                    getChunkIds(dset_id, selection, layout, dim + 1, chunk_id, chunk_ids)
                 last_chunk_index = chunk_index
 
     # got the complete list, return it!

--- a/hsds/util/chunkUtil.py
+++ b/hsds/util/chunkUtil.py
@@ -745,7 +745,7 @@ class ChunkIterator:
         return chunk_id
 
 
-def chunkReadSelection(chunk_arr, slices=None, fields=None):
+def chunkReadSelection(chunk_arr, slices=None, select_dt=None):
     """
     Return data from requested chunk and selection
     """
@@ -761,6 +761,10 @@ def chunkReadSelection(chunk_arr, slices=None, fields=None):
     log.debug(f"got selection: {slices}")
     slices = tuple(slices)
 
+    if select_dt is None:
+        # no field selection
+        select_dt = chunk_arr.dtype
+
     if len(slices) != rank:
         msg = "Selection rank does not match shape rank"
         raise ValueError(msg)
@@ -771,20 +775,13 @@ def chunkReadSelection(chunk_arr, slices=None, fields=None):
     # get requested data
     output_arr = chunk_arr[slices]
 
-    if fields:
-        log.debug(f"ChunkReadSelection fields: {fields}")
-        dtype_items = []
-        if len(fields) > 1:
-            for field in fields:
-                dtype_items.append((field, chunk_arr.dtype[field]))
-            select_dtype = np.dtype(dtype_items)
-        else:
-            # don't need a compound type
-            select_dtype = chunk_arr.dtype[fields[0]]
-        log.debug(f"select_dtype: {select_dtype}")
+    if len(select_dt) < len(dt):
+        # do a field selection
+        log.debug(f"select_dtype: {select_dt}")
         # create an array with just the given fields
-        arr = np.zeros(output_arr.shape, select_dtype)
+        arr = np.zeros(output_arr.shape, select_dt)
         # slot in each of the given fields
+        fields = select_dt.names
         if len(fields) > 1:
             for field in fields:
                 arr[field] = output_arr[field]
@@ -865,7 +862,12 @@ def chunkWriteSelection(chunk_arr=None, slices=None, data=None):
     return updated
 
 
-def chunkReadPoints(chunk_id=None, chunk_layout=None, chunk_arr=None, point_arr=None):
+def chunkReadPoints(chunk_id=None,
+                    chunk_layout=None,
+                    chunk_arr=None,
+                    point_arr=None,
+                    select_dt=None
+                    ):
     """
     Read points from given chunk
     """
@@ -880,6 +882,8 @@ def chunkReadPoints(chunk_id=None, chunk_layout=None, chunk_arr=None, point_arr=
         raise ValueError(msg)
 
     dset_dtype = chunk_arr.dtype
+    if select_dt is None:
+        select_dt = dset_dtype  # no field selection
 
     # verify chunk_layout
     if len(chunk_layout) != rank:
@@ -903,19 +907,32 @@ def chunkReadPoints(chunk_id=None, chunk_layout=None, chunk_arr=None, point_arr=
 
     log.debug(f"got {num_points} points")
 
-    output_arr = np.zeros((num_points,), dtype=dset_dtype)
+    output_arr = np.zeros((num_points,), dtype=select_dt)
 
     chunk_coord = getChunkCoordinate(chunk_id, chunk_layout)
 
     for i in range(num_points):
+        # TBD: there's likely a better way to do this that
+        # doesn't require iterating through each point...
         point = point_arr[i, :]
         tr_point = getChunkRelativePoint(chunk_coord, point)
         val = chunk_arr[tuple(tr_point)]
+        if len(select_dt) < len(dset_dtype):
+            # just update the relevant fields
+            subfield_val = []
+            for (x, field) in zip(val, dset_dtype.names):
+                if field in select_dt.names:
+                    subfield_val.append(x)
+            val = tuple(subfield_val)
         output_arr[i] = val
     return output_arr
 
 
-def chunkWritePoints(chunk_id=None, chunk_layout=None, chunk_arr=None, point_arr=None):
+def chunkWritePoints(chunk_id=None,
+                     chunk_layout=None,
+                     chunk_arr=None,
+                     point_arr=None,
+                     select_dt=None):
     """
     Write points to given chunk
     """
@@ -933,11 +950,13 @@ def chunkWritePoints(chunk_id=None, chunk_layout=None, chunk_arr=None, point_arr
         msg = "Expected point array to be one dimensional"
         raise ValueError(msg)
     dset_dtype = chunk_arr.dtype
+    if select_dt is None:
+        select_dt = dset_dtype  # no field selection
     log.debug(f"dtype: {dset_dtype}")
     log.debug(f"point_arr: {point_arr}")
 
     # point_arr should have the following type:
-    #       (coord1, coord2, ...) | dset_dtype
+    #       (coord1, coord2, ...) | select_dtype
     comp_dtype = point_arr.dtype
     if len(comp_dtype) != 2:
         msg = "expected compound type for point array"
@@ -955,7 +974,7 @@ def chunkWritePoints(chunk_id=None, chunk_layout=None, chunk_arr=None, point_arr
             msg = "unexpected shape for point array"
             raise ValueError(msg)
         dt_1 = comp_dtype[1]
-        if dt_1 != dset_dtype:
+        if dt_1 != select_dt:
             msg = "unexpected dtype for point array"
             raise ValueError(msg)
 
@@ -982,6 +1001,17 @@ def chunkWritePoints(chunk_id=None, chunk_layout=None, chunk_arr=None, point_arr
         log.debug(f"relative coordinate: {coord}")
 
         val = elem[1]  # value
+        if len(select_dt) < len(dset_dtype):
+            # get the element from the chunk
+            chunk_val = list(chunk_arr[coord])
+            # and just update the relevant fields
+            index = 0
+            for (x, field) in zip(val, dset_dtype.names):
+                if field in select_dt.names:
+                    chunk_val[index] = x
+                index += 1
+            val = tuple(chunk_val)  # this will get written back
+
         chunk_arr[coord] = val  # update the point
 
 
@@ -1076,9 +1106,7 @@ def getQueryDtype(dt):
         else:
             break
 
-    dt_fields = [
-        (index_name, "uint64"),
-    ]
+    dt_fields = [(index_name, "uint64"), ]
     for i in range(len(dt)):
         dt_fields.append((dt.names[i], dt[i]))
     query_dt = np.dtype(dt_fields)
@@ -1093,14 +1121,15 @@ def chunkQuery(
     slices=None,
     query=None,
     query_update=None,
+    select_dt=None,
     limit=0,
 ):
     """
     Run query on chunk and selection
     """
-    log.debug(
-        f"chunkQuery - chunk_id: {chunk_id} query: {query} slices: {slices}, limit: {limit}"
-    )
+    msg = f"chunkQuery - chunk_id: {chunk_id} query: {query} slices: {slices}, "
+    msg += f"limit: {limit} select_dt: {select_dt}"
+    log.debug(msg)
 
     if not isinstance(chunk_arr, np.ndarray):
         raise TypeError("unexpected array type")
@@ -1110,6 +1139,8 @@ def chunkQuery(
     rank = len(dims)
 
     dset_dt = chunk_arr.dtype
+    if select_dt is None:
+        select_dt = dset_dt
 
     if rank != 1:
         msg = "Query operations only supported on one-dimensional datasets"
@@ -1199,9 +1230,10 @@ def chunkQuery(
         for i in range(nrows):
             where_indices[i] = where_indices[i] + (s.step - 1) * i
 
-    dt_rsp = getQueryDtype(dset_dt)
+    dt_rsp = getQueryDtype(select_dt)
     # construct response array
     rsp_arr = np.zeros((nrows,), dtype=dt_rsp)
+    field_names = select_dt.names
     for field in field_names:
         rsp_arr[field] = where_result[field]
     index_name = dt_rsp.names[0]

--- a/hsds/util/chunkUtil.py
+++ b/hsds/util/chunkUtil.py
@@ -774,6 +774,7 @@ def chunkReadSelection(chunk_arr, slices=None, fields=None):
     output_arr = chunk_arr[slices]
 
     if fields:
+        log.debug(f"ChunkReadSelection fields: {fields}")
         dtype_items = []
         if len(fields) > 1:
             for field in fields:
@@ -782,12 +783,14 @@ def chunkReadSelection(chunk_arr, slices=None, fields=None):
         else:
             # don't need a compound type
             select_dtype = chunk_arr.dtype[fields[0]]
+        log.debug(f"select_dtype: {select_dtype}")
         # create an array with just the given fields
-        arr = np.zeros(chunk_arr.shape, select_dtype)
+        arr = np.zeros(output_arr.shape, select_dtype)
         # slot in each of the given fields
         if len(fields) > 1:
             for field in fields:
                 arr[field] = output_arr[field]
+            log.debug(f"arr: {arr}")
         else:
             arr[...] = output_arr[fields[0]]
         output_arr = arr  # return this

--- a/hsds/util/dsetUtil.py
+++ b/hsds/util/dsetUtil.py
@@ -306,6 +306,7 @@ def getHyperslabSelection(dsetshape, start=None, stop=None, step=None):
         slices.append(s)
     return tuple(slices)
 
+
 def getSelectionShape(selection):
     """Return the shape of the given selection.
     Examples (selection -> returned shape):
@@ -374,6 +375,7 @@ def getShapeDims(shape):
 
     return dims
 
+
 def isSelectAll(slices, dims):
     """ return True if the selection covers the entire dataspace """
     if len(slices) != len(dims):
@@ -390,7 +392,8 @@ def isSelectAll(slices, dims):
             is_all = False
             break
     return is_all
-    
+
+
 def getQueryParameter(request, query_name, body=None, default=None):
     """
     Herlper function, get query parameter value from request.

--- a/hsds/util/dsetUtil.py
+++ b/hsds/util/dsetUtil.py
@@ -467,29 +467,22 @@ def _getSelectionStringFromRequestBody(body):
         raise KeyError("no start key")
     start_val = body["start"]
     if not isinstance(start_val, (list, tuple)):
-        start_val = [
-            start_val,
-        ]
+        start_val = [start_val, ]
     rank = len(start_val)
     if "stop" not in body:
         raise KeyError("no stop key")
     stop_val = body["stop"]
     if not isinstance(stop_val, (list, tuple)):
-        stop_val = [
-            stop_val,
-        ]
+        stop_val = [stop_val, ]
     if len(stop_val) != rank:
         raise ValueError("start and stop values have different ranks")
     if "step" in body:
         step_val = body["step"]
         if not isinstance(step_val, (list, tuple)):
-            step_val = [
-                step_val,
-            ]
+            step_val = [step_val, ]
         if len(step_val) != rank:
-            raise ValueError(
-                "step values have differnt rank from start and stop selections"
-            )
+            msg = "step values have differnt rank from start and stop selections"
+            raise ValueError(msg)
     else:
         step_val = None
     selection = []
@@ -557,7 +550,7 @@ def _getSelectElements(select):
 def getSelectionList(select, dims):
     """Return tuple of slices and/or coordinate list for the given selection"""
     select_list = []
-
+    log.debug(f"getSelectionList, {select} dims: {dims}")
     if isinstance(select, dict):
         select = _getSelectionStringFromRequestBody(select)
 
@@ -616,9 +609,8 @@ def getSelectionList(select, dims):
                 except ValueError:
                     raise ValueError(f"Invalid selection - start value for dim {dim}")
                 if start < 0 or start >= extent:
-                    raise ValueError(
-                        f"Invalid selection - start value out of range for dim {dim}"
-                    )
+                    msg = f"Invalid selection - start value out of range for dim {dim}"
+                    raise ValueError(msg)
             if len(fields[1]) == 0:
                 stop = extent
             else:
@@ -627,9 +619,8 @@ def getSelectionList(select, dims):
                 except ValueError:
                     raise ValueError(f"Invalid selection - stop value for dim {dim}")
                 if stop < 0 or stop > extent or stop <= start:
-                    raise ValueError(
-                        f"Invalid selection - stop value out of range for dim {dim}"
-                    )
+                    msg = f"Invalid selection - stop value out of range for dim {dim}"
+                    raise ValueError(msg)
             if len(fields) == 3:
                 # get step value
                 if len(fields[2]) == 0:
@@ -638,13 +629,11 @@ def getSelectionList(select, dims):
                     try:
                         step = int(fields[2])
                     except ValueError:
-                        raise ValueError(
-                            f"Invalid selection - step value for dim {dim}"
-                        )
+                        msg = f"Invalid selection - step value for dim {dim}"
+                        raise ValueError(msg)
                     if step <= 0:
-                        raise ValueError(
-                            f"Invalid selection - step value out of range for dim {dim}"
-                        )
+                        msg = f"Invalid selection - step value out of range for dim {dim}"
+                        raise ValueError(msg)
             else:
                 step = 1
             s = slice(start, stop, step)
@@ -656,13 +645,12 @@ def getSelectionList(select, dims):
             except ValueError:
                 raise ValueError(f"Invalid selection - index value for dim {dim}")
             if index < 0 or index >= extent:
-                raise ValueError(
-                    f"Invalid selection - index value out of range for dim {dim}"
-                )
-
+                msg = f"Invalid selection - index value out of range for dim {dim}"
+                raise ValueError(msg)
             s = slice(index, index + 1, 1)
             select_list.append(s)
     # end dimension loop
+    log.debug(f"select_list: {select_list}")
     return tuple(select_list)
 
 

--- a/hsds/util/dsetUtil.py
+++ b/hsds/util/dsetUtil.py
@@ -375,7 +375,23 @@ def getShapeDims(shape):
 
     return dims
 
-
+def isSelectAll(slices, dims):
+    """ return True if the selection covers the entire dataspace """
+    if len(slices) != len(dims):
+        raise ValueError("isSelectAll - dimensions don't match")
+    is_all = True
+    for (s, dim) in zip(slices, dims):
+        if s.step is not None and s.step != 1:
+            is_all = False
+            break
+        if s.start != 0:
+            is_all = False
+            break
+        if s.stop != dim:
+            is_all = False
+            break
+    return is_all
+    
 def getQueryParameter(request, query_name, body=None, default=None):
     """
     Herlper function, get query parameter value from request.

--- a/hsds/util/dsetUtil.py
+++ b/hsds/util/dsetUtil.py
@@ -910,12 +910,13 @@ def getChunkLayout(dset_json):
 def getChunkInitializer(dset_json):
     """ get initializer application and arguments if set """
     initializer = None
-    log.debug(f"getChunkInitializer({dset_json})")
     if "creationProperties" in dset_json:
         cprops = dset_json["creationProperties"]
         log.debug(f"get creationProperties: {cprops}")
         if "initializer" in cprops:
             initializer = cprops["initializer"]
+            dset_id = dset_json["id"]
+            log.debug(f"returning chunk initializer: {initializer} for dset: {dset_id}")
     return initializer
 
 

--- a/hsds/util/dsetUtil.py
+++ b/hsds/util/dsetUtil.py
@@ -234,6 +234,27 @@ def isNullSpace(dset_json):
         return False
 
 
+def isScalarSpace(dset_json):
+    """ return true if this is a scalar dataset """
+    datashape = dset_json["shape"]
+    is_scalar = False
+    if datashape["class"] == "H5S_NULL":
+        is_scalar = False
+    elif datashape["class"] == "H5S_SCALAR":
+        is_scalar = True
+    else:
+        if "dims" not in datashape:
+            log.warn(f"expected to find dims key in shape_json: {datashape}")
+            is_scalar = False
+        else:
+            dims = datashape["dims"]
+            if len(dims) == 0:
+                # guess this properly be a H5S_SCALAR class
+                # but treat this as equivalent
+                is_scalar = True
+    return is_scalar
+
+
 def getHyperslabSelection(dsetshape, start=None, stop=None, step=None):
     """
     Get slices given lists of start, stop, step values

--- a/hsds/util/dsetUtil.py
+++ b/hsds/util/dsetUtil.py
@@ -306,7 +306,6 @@ def getHyperslabSelection(dsetshape, start=None, stop=None, step=None):
         slices.append(s)
     return tuple(slices)
 
-
 def getSelectionShape(selection):
     """Return the shape of the given selection.
     Examples (selection -> returned shape):

--- a/hsds/util/hdf5dtype.py
+++ b/hsds/util/hdf5dtype.py
@@ -830,12 +830,16 @@ def getSubType(dt_parent, fields):
     """
     if len(dt_parent) == 0:
         raise TypeError("getSubType - parent must be compound type")
+    if not fields:
+        raise TypeError("null field specification")
+    if isinstance(fields, str):
+        fields = [fields,]  # convert to a list
+    
     field_names = set(dt_parent.names)
     dt_items = []
     for field in fields:
         if field not in field_names:
             raise TypeError(f"field: {field} is not defined in parent type")
-
         dt_items.append((field, dt_parent[field]))
     dt = np.dtype(dt_items)
 

--- a/hsds/util/hdf5dtype.py
+++ b/hsds/util/hdf5dtype.py
@@ -823,6 +823,7 @@ def getBaseTypeJson(type_name):
         raise TypeError("Invalid type name")
     return type_json
 
+
 def getSubType(dt_parent, fields):
     """ Return a dtype that is a compound type composed of
         the fields given in the field_names list
@@ -834,7 +835,7 @@ def getSubType(dt_parent, fields):
     for field in fields:
         if field not in field_names:
             raise TypeError(f"field: {field} is not defined in parent type")
-                   
+
         dt_items.append((field, dt_parent[field]))
     dt = np.dtype(dt_items)
 

--- a/hsds/util/hdf5dtype.py
+++ b/hsds/util/hdf5dtype.py
@@ -822,3 +822,20 @@ def getBaseTypeJson(type_name):
     else:
         raise TypeError("Invalid type name")
     return type_json
+
+def getSubType(dt_parent, fields):
+    """ Return a dtype that is a compound type composed of
+        the fields given in the field_names list
+    """
+    if len(dt_parent) == 0:
+        raise TypeError("getSubType - parent must be compound type")
+    field_names = set(dt_parent.names)
+    dt_items = []
+    for field in fields:
+        if field not in field_names:
+            raise TypeError(f"field: {field} is not defined in parent type")
+                   
+        dt_items.append((field, dt_parent[field]))
+    dt = np.dtype(dt_items)
+
+    return dt

--- a/hsds/util/hdf5dtype.py
+++ b/hsds/util/hdf5dtype.py
@@ -834,7 +834,7 @@ def getSubType(dt_parent, fields):
         raise TypeError("null field specification")
     if isinstance(fields, str):
         fields = [fields,]  # convert to a list
-    
+
     field_names = set(dt_parent.names)
     dt_items = []
     for field in fields:

--- a/hsds/util/rangegetUtil.py
+++ b/hsds/util/rangegetUtil.py
@@ -51,7 +51,7 @@ def _chunk_dist(chunk_left, chunk_right):
 def _find_min_pair(h5chunks, max_gap=None):
     """ Given a list of chunk_map entries which are sorted by offset,
         return the indicies of the two chunks nearest to each other in the file.
-        If max_gap is set, chunms must be within max_gap bytes
+        If max_gap is set, chunks must be within max_gap bytes
     """
     num_chunks = len(h5chunks)
 

--- a/hsds/util/storUtil.py
+++ b/hsds/util/storUtil.py
@@ -220,10 +220,13 @@ def _uncompress(data, compressor=None, shuffle=0, level=None, dtype=None, chunk_
             raise HTTPInternalServerError()
     if shuffle:
         data = _unshuffle(shuffle, data, dtype=dtype, chunk_shape=chunk_shape)
-    finish_time = time.time()
-    elapsed = finish_time - start_time
-    msg = f"uncompressed {len(data)} bytes, {(elapsed):.3f}s elapsed"
-    log.debug(msg)
+
+    if compressor or shuffle:
+        # log the decompression time
+        finish_time = time.time()
+        elapsed = finish_time - start_time
+        msg = f"uncompressed {len(data)} bytes, {(elapsed):.3f}s elapsed"
+        log.debug(msg)
 
     return data
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 requires-python = ">=3.8"
-version = "0.8.4"
+version = "0.8.5"
 
 dependencies = [
     "aiohttp == 3.8.5",

--- a/tests/integ/query_test.py
+++ b/tests/integ/query_test.py
@@ -243,9 +243,7 @@ class QueryTest(unittest.TestCase):
         if "snp500.h5" not in snp500_json:
             self.assertTrue(False)
 
-        chunk_dims = [
-            60000,
-        ]  # chunk layout used in snp500.h5 file
+        chunk_dims = [60000, ]  # chunk layout used in snp500.h5 file
         num_chunks = (SNP500_ROWS // chunk_dims[0]) + 1
 
         chunk_info = snp500_json["snp500.h5"]

--- a/tests/integ/setup_test.py
+++ b/tests/integ/setup_test.py
@@ -49,10 +49,7 @@ class SetupTest(unittest.TestCase):
 
         req = helper.getEndpoint() + '/'
         params = {"domain": home_domain}
-        print("req:", req)
-        print("domain:", home_domain)
         rsp = self.session.get(req, params=params, headers=headers)
-        print("/home get status:", rsp.status_code)
 
         if rsp.status_code == 404:
             if not admin_headers:
@@ -67,7 +64,6 @@ class SetupTest(unittest.TestCase):
                                    data=json.dumps(body),
                                    params=params,
                                    headers=admin_headers)
-            print("put request status:", rsp.status_code)
             self.assertEqual(rsp.status_code, 201)
             # do the original request again
             rsp = self.session.get(req, params=params, headers=headers)
@@ -76,18 +72,15 @@ class SetupTest(unittest.TestCase):
                   "set env variable for USER_PASSWORD")
             self.assertTrue(False)
 
-        print("got status code:", rsp.status_code)
         self.assertEqual(rsp.status_code, 200)
 
         rspJson = json.loads(rsp.text)
-        print("home folder json:", rspJson)
         for k in ("owner", "created", "lastModified"):
             self.assertTrue(k in rspJson)
         self.assertFalse("root" in rspJson)  # no root -> folder
 
         params = {"domain": user_domain}
         rsp = self.session.get(req, params=params, headers=headers)
-        print(f"{user_domain} get status: {rsp.status_code}")
         if rsp.status_code == 404:
             if not admin_headers:
                 print(f"{user_domain} folder doesn't exist, set ADMIN_USERNAME "
@@ -106,7 +99,6 @@ class SetupTest(unittest.TestCase):
 
         self.assertEqual(rsp.status_code, 200)
         rspJson = json.loads(rsp.text)
-        print("user folder:", rspJson)
         self.assertFalse("root" in rspJson)  # no root group for folder domain
         self.assertTrue("owner" in rspJson)
         self.assertTrue("hrefs" in rspJson)

--- a/tests/integ/value_test.py
+++ b/tests/integ/value_test.py
@@ -2133,7 +2133,7 @@ class ValueTest(unittest.TestCase):
 
         # create the dataset with a 0-sized shape
         req = self.endpoint + "/datasets"
-        payload = {"type": "H5T_STD_I32LE", "shape": [0, 0], "maxdims": [0, 0]}
+        payload = {"type": "H5T_STD_I32LE", "shape": [1, 0], "maxdims": [0, 0]}
         req = self.endpoint + "/datasets"
         rsp = self.session.post(req, data=json.dumps(payload), headers=headers)
         self.assertEqual(rsp.status_code, 201)  # create dataset

--- a/tests/integ/value_test.py
+++ b/tests/integ/value_test.py
@@ -1095,10 +1095,33 @@ class ValueTest(unittest.TestCase):
         self.assertTrue("value" in rspJson)
 
         readData = rspJson["value"]
+        self.assertEqual(len(readData), num_elements)
+        for i in range(num_elements):
+            item = readData[i]
+            self.assertEqual(len(item), 2)
+            expected = (i * 10, i * 10 + i / 10.0) if i > 0 else (42, 0.42)
+            self.assertEqual(item[0], expected[0])
+            tol = 0.1  # tbd: investiage why results need such a high tolerance
+            self.assertTrue(abs(item[1] - expected[1]) < tol)
 
         self.assertEqual(readData[0][0], 42)
         self.assertEqual(readData[1][0], 10)
 
+        # read back just the "temp" field of the compound type
+        params = {"fields": "temp"}
+        rsp = self.session.get(req, params=params, headers=headers)
+        self.assertEqual(rsp.status_code, 200)
+        rspJson = json.loads(rsp.text)
+        self.assertTrue("hrefs" in rspJson)
+        self.assertTrue("value" in rspJson)
+
+        readData = rspJson["value"]
+        self.assertEqual(len(readData), num_elements)
+        for i in range(num_elements):
+            elem = readData[i]
+            self.assertEqual(len(elem), 1)
+            expected = i * 10 if i > 0 else 42
+            self.assertEqual(elem[0], expected)
         #
         # create 2d dataset
         #
@@ -1145,6 +1168,22 @@ class ValueTest(unittest.TestCase):
         self.assertEqual(readData[0][1], [0, 0.5])
         self.assertEqual(readData[1][1], [10, 10.5])
 
+        # read back just the "temp" field of the compound type
+        params = {"fields": "temp"}
+        rsp = self.session.get(req, params=params, headers=headers)
+        self.assertEqual(rsp.status_code, 200)
+        rspJson = json.loads(rsp.text)
+        self.assertTrue("hrefs" in rspJson)
+        self.assertTrue("value" in rspJson)
+
+        readData = rspJson["value"]
+        for i in range(dims[0]):
+            row = readData[i]
+            for j in range(dims[1]):
+                item = row[j]
+                self.assertEqual(len(item), 1)
+                self.assertEqual(item[0], i * 10)
+
     def testSimpleTypeFillValue(self):
         # test Dataset with simple type and fill value
         print("testSimpleTypeFillValue", self.base_domain)
@@ -1184,16 +1223,12 @@ class ValueTest(unittest.TestCase):
         rspJson = json.loads(rsp.text)
         self.assertTrue("hrefs" in rspJson)
         self.assertTrue("value" in rspJson)
-        expected_value = [
-            42,
-        ]
+        expected_value = [42, ]
         expected_value *= 10
         self.assertEqual(rspJson["value"], expected_value)
 
         # write some values
-        value = [
-            24,
-        ]
+        value = [24, ]
         value *= 5
         payload = {"start": 0, "stop": 5, "value": value}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -1258,9 +1293,7 @@ class ValueTest(unittest.TestCase):
         rspJson = json.loads(rsp.text)
         shape = rspJson["shape"]
         self.assertEqual(shape["class"], "H5S_SIMPLE")
-        expected_value = [
-            40,
-        ]
+        expected_value = [40, ]
         self.assertEqual(shape["dims"], expected_value)
 
         # read the default values
@@ -1344,16 +1377,12 @@ class ValueTest(unittest.TestCase):
         rspJson = json.loads(rsp.text)
         self.assertTrue("hrefs" in rspJson)
         self.assertTrue("value" in rspJson)
-        expected_value = [
-            fill_value,
-        ]
+        expected_value = [fill_value, ]
         expected_value *= 10
         self.assertEqual(rspJson["value"], expected_value)
 
         # write some values
-        value = [
-            "hello",
-        ]
+        value = ["hello", ]
         value *= 5
         payload = {"start": 0, "stop": 5, "value": value}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -1427,9 +1456,7 @@ class ValueTest(unittest.TestCase):
             self.assertEqual(ret_values[i], None)
 
         # write some values
-        value = [
-            3.12,
-        ]
+        value = [3.12, ]
         value *= 5
         payload = {"start": 0, "stop": 5, "value": value}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -2420,9 +2447,7 @@ class ValueTest(unittest.TestCase):
 
         # read a selection
         req = self.endpoint + "/datasets/" + dset_id + "/value"
-        params = {
-            "select": "[1234567:1234568]"
-        }  # read 1 element, starting at index 1234567
+        params = {"select": "[1234567:1234568]"}  # read 1 element, starting at index 1234567
         params["nonstrict"] = 1  # allow use of aws lambda if configured
         rsp = self.session.get(req, params=params, headers=headers)
         if rsp.status_code == 404:
@@ -2443,6 +2468,24 @@ class ValueTest(unittest.TestCase):
         self.assertEqual(item[1], "MHFI")
         self.assertEqual(item[2], 3)
         # skip check rest of fields since float comparisons are trcky...
+
+        # do a select with just the fields: date, symbol, sector
+        params["fields"] = "date:symbol:sector"
+        rsp = self.session.get(req, params=params, headers=headers)
+        self.assertEqual(rsp.status_code, 200)
+        rspJson = json.loads(rsp.text)
+        self.assertTrue("hrefs" in rspJson)
+        self.assertTrue("value" in rspJson)
+        value = rspJson["value"]
+        # should get one element back (still have the select param...)
+        self.assertEqual(len(value), 1)
+        item = value[0]
+        print(item)
+        # verify that this is what we expected to get
+        self.assertEqual(len(item), 3)
+        self.assertEqual(item[0], "1998.10.22")
+        self.assertEqual(item[1], "MHFI")
+        self.assertEqual(item[2], 3)
 
     def testChunkedRefIndirectDataset(self):
         test_name = "testChunkedRefIndirectDataset"


### PR DESCRIPTION
Add support for sub-field selection in hyperslab, point, and query operations for both reading and write.
To specify which fields of a compound type are to be accessed, add a query param or body key of "fields".  For a single field selection the query value can just be the field name.  If multiple fields are to be accessed, concatenate the field names with a colon separator.