### PR TITLE
Support requests with long URL

### DIFF
--- a/admin/config/config.yml
+++ b/admin/config/config.yml
@@ -49,6 +49,7 @@ max_task_count: 100 # maximum number of concurrent tasks before server will retu
 max_tasks_per_node_per_request: 16 # maximum number of inflight tasks to to each node per request
 aio_max_pool_connections: 64 # number of connections to keep in conection pool for aiobotocore requests
 client_pool_count: 10 # pool count for SessionClient
+aio_max_line_size: 67584 # max size of a single line of http in aiohttp application
 metadata_mem_cache_size: 128m # 128 MB - metadata cache size per DN node
 metadata_mem_cache_expire: 3600 # expire cache items after one hour
 chunk_mem_cache_size: 128m # 128 MB - chunk cache size per DN node

--- a/hsds/basenode.py
+++ b/hsds/basenode.py
@@ -553,8 +553,10 @@ def baseInit(node_type):
     log.setLogConfig(log_level, prefix=prefix, timestamps=log_timestamps)
 
     # create the app object
+    aio_max_line_size = config.get("aio_max_line_size")
+
     log.info("Application baseInit")
-    app = Application()
+    app = Application(handler_args={"max_line_size": aio_max_line_size})
 
     app["node_state"] = "INITIALIZING"
     app["node_number"] = -1


### PR DESCRIPTION
This allows for users to have link/group names up to about 64Kb, which the main library supports. 

The specific choice of 67584 for the default max size is `65 * 1024 + 2048`. This is because the library's API tests include a link with a name that is `65 * 1024` bytes long, and  2048 bytes should be enough to store the rest of the URL.