### PR TITLE
Silence user-defined path warning

### DIFF
--- a/hsds/util/fileClient.py
+++ b/hsds/util/fileClient.py
@@ -190,7 +190,7 @@ class FileClient:
             raise HTTPNotFound()
 
         start_time = time.time()
-        filepath = self._getFilePath(bucket, key)
+        filepath = pp.normpath(self._getFilePath(bucket, key))
         log.debug(f"fileClient.put_object({bucket}/{key} start: {start_time}")
         loop = asyncio.get_event_loop()
         try:


### PR DESCRIPTION
This is redundant since `_getFilePath` already normalizes the path, but this quiets the CodeQL warnings. 