### PR TITLE
Make link API consistently expect 'grp_ids'

### DIFF
--- a/hsds/link_sn.py
+++ b/hsds/link_sn.py
@@ -368,8 +368,8 @@ async def PUT_Links(request):
     # next, sort out where these attributes are going to
 
     grp_ids = {}
-    if "group_ids" in body:
-        body_ids = body["group_ids"]
+    if "grp_ids" in body:
+        body_ids = body["grp_ids"]
         if isinstance(body_ids, list):
             # multi cast the links - each link  in link_items
             # will be written to each of the objects identified by obj_id
@@ -583,8 +583,8 @@ async def POST_Links(request):
     else:
         titles = None
 
-    if "group_ids" in body:
-        group_ids = body["group_ids"]
+    if "grp_ids" in body:
+        group_ids = body["grp_ids"]
     else:
         group_ids = None
 

--- a/hsds/link_sn.py
+++ b/hsds/link_sn.py
@@ -368,8 +368,8 @@ async def PUT_Links(request):
     # next, sort out where these attributes are going to
 
     grp_ids = {}
-    if "grp_ids" in body:
-        body_ids = body["grp_ids"]
+    if "group_ids" in body:
+        body_ids = body["group_ids"]
         if isinstance(body_ids, list):
             # multi cast the links - each link  in link_items
             # will be written to each of the objects identified by obj_id
@@ -393,7 +393,7 @@ async def PUT_Links(request):
             # unlike the above case, different attributes can be written to
             # different objects
             if link_items:
-                msg = "links defined outside the obj_ids dict"
+                msg = "links defined outside the group_ids dict"
                 log.warn(msg)
                 raise HTTPBadRequest(reason=msg)
             else:
@@ -609,7 +609,7 @@ async def POST_Links(request):
             items[group_id] = None
     elif isinstance(group_ids, dict):
         if titles is not None:
-            msg = "titles must not be provided if obj_ids is a dict"
+            msg = "titles must not be provided if group_ids is a dict"
             log.warn(msg)
             raise HTTPBadRequest(reason=msg)
         for group_id in group_ids:

--- a/tests/integ/link_test.py
+++ b/tests/integ/link_test.py
@@ -352,7 +352,7 @@ class LinkTest(unittest.TestCase):
                     params["CreateOrder"] = 1
 
                 if use_post:
-                    payload = {"group_ids": [root_id, ]}
+                    payload = {"grp_ids": [root_id, ]}
                     data = json.dumps(payload)
                     rsp = self.session.post(req, data=data, params=params, headers=headers)
                 else:
@@ -400,7 +400,7 @@ class LinkTest(unittest.TestCase):
                 if creation_order:
                     params["CreateOrder"] = 1
                 if use_post:
-                    payload = {"group_ids": [root_id, ]}
+                    payload = {"grp_ids": [root_id, ]}
                     data = json.dumps(payload)
                     rsp = self.session.post(req, data=data, params=params, headers=headers)
                 else:
@@ -670,7 +670,7 @@ class LinkTest(unittest.TestCase):
             req = helper.getEndpoint() + "/groups/" + g1_2_uuid + "/links"
             params = {"pattern": "ext*"}
             if use_post:
-                payload = {"group_ids": [g1_2_uuid, ]}
+                payload = {"grp_ids": [g1_2_uuid, ]}
                 data = json.dumps(payload)
                 rsp = self.session.post(req, data=data, params=params, headers=headers)
             else:
@@ -698,7 +698,7 @@ class LinkTest(unittest.TestCase):
             req = helper.getEndpoint() + "/groups/" + root_uuid + "/links"
             params = {"follow_links": 1, "pattern": "dset*"}
             if use_post:
-                payload = {"group_ids": [root_uuid, ]}
+                payload = {"grp_ids": [root_uuid, ]}
                 data = json.dumps(payload)
                 rsp = self.session.post(req, data=data, params=params, headers=headers)
             else:
@@ -1260,7 +1260,7 @@ class LinkTest(unittest.TestCase):
 
         # get all links for the given set of group ids
         grp_ids = list(grp_map.keys())
-        payload = {"group_ids": grp_ids}
+        payload = {"grp_ids": grp_ids}
         req = helper.getEndpoint() + "/groups/" + root_id + "/links"
         rsp = self.session.post(req, data=json.dumps(payload), headers=headers)
         self.assertEqual(rsp.status_code, 200)
@@ -1293,7 +1293,7 @@ class LinkTest(unittest.TestCase):
         # get just the requested links for each group
         req = helper.getEndpoint() + "/groups/" + root_id + "/links"
         link_map = {g1_id: ["g1.1", "g1.2"], g2_id: ["dset2.2", ]}
-        payload = {"group_ids": link_map}
+        payload = {"grp_ids": link_map}
         rsp = self.session.post(req, data=json.dumps(payload), headers=headers)
         self.assertEqual(rsp.status_code, 200)
         rspJson = json.loads(rsp.text)
@@ -1317,7 +1317,7 @@ class LinkTest(unittest.TestCase):
         # get all links for the domain by providing the root_id with the follow_links param
         params = {"follow_links": 1}
         grp_ids = [root_id, ]
-        payload = {"group_ids": grp_ids}
+        payload = {"grp_ids": grp_ids}
         rsp = self.session.post(req, data=json.dumps(payload), params=params, headers=headers)
         self.assertEqual(rsp.status_code, 200)
         rspJson = json.loads(rsp.text)
@@ -1453,7 +1453,7 @@ class LinkTest(unittest.TestCase):
         links["softlink_multicast"] = {"h5path": "multi_path"}
         links["extlink_multicast"] = {"h5path": "multi_path", "h5domain": "/another_domain"}
         link_count = len(links)
-        data = {"links": links, "group_ids": grp_ids}
+        data = {"links": links, "grp_ids": grp_ids}
         req = self.endpoint + "/groups/" + root_id + "/links"
         rsp = self.session.put(req, data=json.dumps(data), headers=headers)
         self.assertEqual(rsp.status_code, 201)
@@ -1495,7 +1495,7 @@ class LinkTest(unittest.TestCase):
             links[f"extlink_{i}"] = ext_link
             link_data[grp_id] = {"links": links}
 
-        data = {"group_ids": link_data}
+        data = {"grp_ids": link_data}
         req = self.endpoint + "/groups/" + root_id + "/links"
         rsp = self.session.put(req, data=json.dumps(data), headers=headers)
         self.assertEqual(rsp.status_code, 201)

--- a/tests/integ/link_test.py
+++ b/tests/integ/link_test.py
@@ -578,7 +578,7 @@ class LinkTest(unittest.TestCase):
         hrefs = rspJson["hrefs"]
         self.assertEqual(len(hrefs), 3)
         self.assertTrue("links" in rspJson)
-        obj_map = rspJson["links"]  # map of obj_ids to links
+        obj_map = rspJson["links"]  # map of group_ids to links
         hardlink_count = 0
         softlink_count = 0
         extlink_count = 0
@@ -637,7 +637,7 @@ class LinkTest(unittest.TestCase):
         hrefs = rspJson["hrefs"]
         self.assertEqual(len(hrefs), 3)
         self.assertTrue("links" in rspJson)
-        obj_map = rspJson["links"]  # map of obj_ids to links
+        obj_map = rspJson["links"]  # map of group_ids to links
         link_count = 0
         for obj_id in obj_map:
             link_count += len(obj_map[obj_id])
@@ -1453,7 +1453,7 @@ class LinkTest(unittest.TestCase):
         links["softlink_multicast"] = {"h5path": "multi_path"}
         links["extlink_multicast"] = {"h5path": "multi_path", "h5domain": "/another_domain"}
         link_count = len(links)
-        data = {"links": links, "grp_ids": grp_ids}
+        data = {"links": links, "group_ids": grp_ids}
         req = self.endpoint + "/groups/" + root_id + "/links"
         rsp = self.session.put(req, data=json.dumps(data), headers=headers)
         self.assertEqual(rsp.status_code, 201)
@@ -1495,7 +1495,7 @@ class LinkTest(unittest.TestCase):
             links[f"extlink_{i}"] = ext_link
             link_data[grp_id] = {"links": links}
 
-        data = {"grp_ids": link_data}
+        data = {"group_ids": link_data}
         req = self.endpoint + "/groups/" + root_id + "/links"
         rsp = self.session.put(req, data=json.dumps(data), headers=headers)
         self.assertEqual(rsp.status_code, 201)


### PR DESCRIPTION
Currently, `PUT_Links` expects `grp_ids` and `POST_Links` expects `group_ids`. 