### PR TITLE
Fix link test using old param name

### DIFF
--- a/tests/integ/link_test.py
+++ b/tests/integ/link_test.py
@@ -1397,7 +1397,7 @@ class LinkTest(unittest.TestCase):
         req = helper.getEndpoint() + "/groups/" + root_id + "/links"
         group_ids = [root_id, group_id]
         titles = ["link1"]
-        body = {"group_ids": group_ids, "titles": titles}
+        body = {"grp_ids": group_ids, "titles": titles}
         rsp = self.session.post(req, data=json.dumps(body), headers=headers)
         self.assertEqual(rsp.status_code, 200)
         rspJson = json.loads(rsp.text)


### PR DESCRIPTION
The test used the old parameter `group_ids` instead of the new `grp_ids`, causing the parameter to go unrecognized and the test to fail every time. 