### PR TITLE
Restrict bucket names to alphanumeric characters and underscores

### DIFF
--- a/hsds/attr_dn.py
+++ b/hsds/attr_dn.py
@@ -25,6 +25,7 @@ from .util.globparser import globmatch
 from .util.dsetUtil import getShapeDims
 from .util.arrayUtil import arrayToBytes, jsonToArray, decodeData
 from .util.arrayUtil import bytesToArray, bytesArrayToList, getNumElements
+from .util.domainUtil import isValidBucketName
 from .datanode_lib import get_obj_id, get_metadata_obj, save_metadata_obj
 from . import hsds_logger as log
 
@@ -149,6 +150,11 @@ async def GET_Attributes(request):
         bucket = params["bucket"]
     else:
         msg = "POST Attributes without bucket param"
+        log.warn(msg)
+        raise HTTPBadRequest(reason=msg)
+
+    if not isValidBucketName(bucket):
+        msg = f"Invalid bucket name: {bucket}"
         log.warn(msg)
         raise HTTPBadRequest(reason=msg)
 
@@ -279,6 +285,11 @@ async def POST_Attributes(request):
         log.warn(msg)
         raise HTTPBadRequest(reason=msg)
 
+    if not isValidBucketName(bucket):
+        msg = f"Invalid bucket name: {bucket}"
+        log.warn(msg)
+        raise HTTPBadRequest(reason=msg)
+
     include_data = False
     log.debug(f"got params: {params}")
     if "IncludeData" in params and params["IncludeData"]:
@@ -360,9 +371,14 @@ async def PUT_Attributes(request):
     if "bucket" in params:
         bucket = params["bucket"]
     elif "bucket" in body:
-        bucket = params["bucket"]
+        bucket = body["bucket"]
     else:
         msg = "PUT Attributes without bucket param"
+        log.warn(msg)
+        raise HTTPBadRequest(reason=msg)
+
+    if not isValidBucketName(bucket):
+        msg = f"Invalid bucket name: {bucket}"
         log.warn(msg)
         raise HTTPBadRequest(reason=msg)
 
@@ -521,6 +537,11 @@ async def DELETE_Attributes(request):
         bucket = params["bucket"]
     else:
         msg = "DELETE Attributes without bucket param"
+        log.warn(msg)
+        raise HTTPBadRequest(reason=msg)
+
+    if not isValidBucketName(bucket):
+        msg = f"Invalid bucket name: {bucket}"
         log.warn(msg)
         raise HTTPBadRequest(reason=msg)
 

--- a/hsds/chunk_dn.py
+++ b/hsds/chunk_dn.py
@@ -29,6 +29,7 @@ from .util.dsetUtil import getSelectionShape, getChunkInitializer
 from .util.chunkUtil import getChunkIndex, getDatasetId, chunkQuery
 from .util.chunkUtil import chunkWriteSelection, chunkReadSelection
 from .util.chunkUtil import chunkWritePoints, chunkReadPoints
+from .util.domainUtil import isValidBucketName
 from .util.boolparser import BooleanParser
 from .datanode_lib import get_metadata_obj, get_chunk, save_chunk
 
@@ -81,6 +82,10 @@ async def PUT_Chunk(request):
         msg = "PUT_Chunk - bucket is None"
         log.warn(msg)
         raise HTTPInternalServerError(reason=msg)
+    elif not isValidBucketName(bucket):
+        msg = f"Invalid bucket name: {bucket}"
+        log.warn(msg)
+        raise HTTPBadRequest(reason=msg)
 
     if "element_count" in params:
         try:
@@ -343,6 +348,10 @@ async def GET_Chunk(request):
         msg = "GET_Chunk - bucket is None"
         log.warn(msg)
         raise HTTPBadRequest(reason=msg)
+    elif not isValidBucketName(bucket):
+        msg = f"Invalid bucket name: {bucket}"
+        log.warn(msg)
+        raise HTTPBadRequest(reason=msg)
 
     log.debug(f"GET_Chunk - using bucket: {bucket}")
 
@@ -584,6 +593,11 @@ async def POST_Chunk(request):
 
     bucket = params["bucket"]
 
+    if not isValidBucketName(bucket):
+        msg = f"Invalid bucket name: {bucket}"
+        log.warn(msg)
+        raise HTTPBadRequest(reason=msg)
+
     s3path = None
     s3offset = 0
     s3size = 0
@@ -812,6 +826,10 @@ async def DELETE_Chunk(request):
 
     if not bucket:
         msg = "DELETE_Chunk - bucket param not set"
+        log.warn(msg)
+        raise HTTPBadRequest(reason=msg)
+    elif not isValidBucketName(bucket):
+        msg = f"Invalid bucket name: {bucket}"
         log.warn(msg)
         raise HTTPBadRequest(reason=msg)
 

--- a/hsds/ctype_dn.py
+++ b/hsds/ctype_dn.py
@@ -22,6 +22,7 @@ from aiohttp.web import json_response
 from .util.idUtil import isValidUuid, validateUuid
 from .datanode_lib import get_obj_id, get_metadata_obj, save_metadata_obj
 from .datanode_lib import delete_metadata_obj, check_metadata_obj
+from .util.domainUtil import isValidBucketName
 from . import hsds_logger as log
 
 
@@ -40,6 +41,11 @@ async def GET_Datatype(request):
         bucket = params["bucket"]
     else:
         bucket = None
+
+    if not isValidBucketName(bucket):
+        msg = f"Invalid bucket name: {bucket}"
+        log.warn(msg)
+        raise HTTPBadRequest(reason=msg)
 
     ctype_json = await get_metadata_obj(app, ctype_id, bucket=bucket)
 
@@ -74,9 +80,14 @@ async def POST_Datatype(request):
     if "bucket" in params:
         bucket = params["bucket"]
     elif "bucket" in body:
-        bucket = params["bucket"]
+        bucket = body["bucket"]
     else:
         bucket = None
+
+    if not isValidBucketName(bucket):
+        msg = f"Invalid bucket name: {bucket}"
+        log.warn(msg)
+        raise HTTPBadRequest(reason=msg)
 
     ctype_id = get_obj_id(request, body=body)
     if not isValidUuid(ctype_id, obj_class="datatype"):
@@ -152,6 +163,11 @@ async def DELETE_Datatype(request):
         bucket = params["bucket"]
     else:
         bucket = app["bucket_name"]
+
+    if not isValidBucketName(bucket):
+        msg = f"Invalid bucket name: {bucket}"
+        log.warn(msg)
+        raise HTTPBadRequest(reason=msg)
 
     if not bucket:
         msg = "DELETE_Datatype - bucket not set"

--- a/hsds/domain_sn.py
+++ b/hsds/domain_sn.py
@@ -32,7 +32,7 @@ from .util.idUtil import isValidUuid, isSchema2Id, getNodeCount
 from .util.authUtil import getUserPasswordFromRequest, aclCheck, isAdminUser
 from .util.authUtil import validateUserPassword, getAclKeys
 from .util.domainUtil import getParentDomain, getDomainFromRequest
-from .util.domainUtil import isValidDomain, getBucketForDomain
+from .util.domainUtil import isValidDomain, getBucketForDomain, isValidBucketName
 from .util.domainUtil import getPathForDomain, getLimits
 from .util.storUtil import getStorKeys, getCompressors
 from .util.boolparser import BooleanParser
@@ -225,6 +225,11 @@ async def get_domains(request):
         msg = "no bucket specified for request"
         log.warn(msg)
         raise HTTPBadRequest(reason=msg)
+    elif not isValidBucketName(bucket):
+        msg = f"Invalid bucket name: {bucket}"
+        log.warn(msg)
+        raise HTTPBadRequest(reason=msg)
+
     log.info(f"get_domains - prefix: {prefix} bucket: {bucket}")
 
     # list the S3 keys for this prefix

--- a/hsds/dset_dn.py
+++ b/hsds/dset_dn.py
@@ -20,6 +20,7 @@ from aiohttp.web import json_response
 
 
 from .util.idUtil import isValidUuid, validateUuid
+from .util.domainUtil import isValidBucketName
 from .datanode_lib import get_obj_id, check_metadata_obj, get_metadata_obj
 from .datanode_lib import save_metadata_obj, delete_metadata_obj
 from . import hsds_logger as log
@@ -39,6 +40,11 @@ async def GET_Dataset(request):
         bucket = params["bucket"]
     else:
         bucket = None
+
+    if not isValidBucketName(bucket):
+        msg = f"Invalid bucket name: {bucket}"
+        log.warn(msg)
+        raise HTTPBadRequest(reason=msg)
 
     dset_json = await get_metadata_obj(app, dset_id, bucket=bucket)
 
@@ -81,6 +87,11 @@ async def POST_Dataset(request):
         bucket = params["bucket"]
     else:
         bucket = None
+
+    if not isValidBucketName(bucket):
+        msg = f"Invalid bucket name: {bucket}"
+        log.warn(msg)
+        raise HTTPBadRequest(reason=msg)
 
     dset_id = get_obj_id(request, body=body)
     if not isValidUuid(dset_id, obj_class="dataset"):
@@ -178,6 +189,10 @@ async def DELETE_Dataset(request):
         msg = "DELETE_Dataset - bucket not set"
         log.error(msg)
         raise HTTPBadRequest(reason=msg)
+    elif not isValidBucketName(bucket):
+        msg = f"Invalid bucket name: {bucket}"
+        log.warn(msg)
+        raise HTTPBadRequest(reason=msg)
 
     # verify the id  exist
     obj_found = await check_metadata_obj(app, dset_id, bucket=bucket)
@@ -223,6 +238,11 @@ async def PUT_DatasetShape(request):
         bucket = params["bucket"]
     else:
         bucket = None
+
+    if not isValidBucketName(bucket):
+        msg = f"Invalid bucket name: {bucket}"
+        log.warn(msg)
+        raise HTTPBadRequest(reason=msg)
 
     dset_json = await get_metadata_obj(app, dset_id, bucket=bucket)
 

--- a/hsds/group_dn.py
+++ b/hsds/group_dn.py
@@ -21,6 +21,7 @@ from aiohttp.web_exceptions import HTTPNotFound, HTTPServiceUnavailable
 from aiohttp.web import json_response
 
 from .util.idUtil import isValidUuid, isSchema2Id, isRootObjId, getRootObjId
+from .util.domainUtil import isValidBucketName
 from .datanode_lib import get_obj_id, check_metadata_obj, get_metadata_obj
 from .datanode_lib import save_metadata_obj, delete_metadata_obj
 from . import hsds_logger as log
@@ -37,6 +38,12 @@ async def GET_Group(request):
         bucket = params["bucket"]
     else:
         bucket = None
+
+    if not isValidBucketName(bucket):
+        msg = f"Invalid bucket name: {bucket}"
+        log.warn(msg)
+        raise HTTPBadRequest(reason=msg)
+
     log.info(f"GET group: {group_id} bucket: {bucket}")
 
     if not isValidUuid(group_id, obj_class="group"):
@@ -83,6 +90,11 @@ async def POST_Group(request):
         bucket = params["bucket"]
     else:
         bucket = None
+
+    if not isValidBucketName(bucket):
+        msg = f"Invalid bucket name: {bucket}"
+        log.warn(msg)
+        raise HTTPBadRequest(reason=msg)
 
     group_id = get_obj_id(request, body=body)
 
@@ -156,6 +168,12 @@ async def PUT_Group(request):
         bucket = params["bucket"]
     else:
         bucket = None
+
+    if not isValidBucketName(bucket):
+        msg = f"Invalid bucket name: {bucket}"
+        log.warn(msg)
+        raise HTTPBadRequest(reason=msg)
+
     log.info(f"PUT group (flush): {root_id}  bucket: {bucket}")
     # don't really need bucket param since the dirty ids know which bucket
     # they should write too
@@ -242,6 +260,10 @@ async def DELETE_Group(request):
         msg = "DELETE_Group - bucket not set"
         log.error(msg)
         raise HTTPBadRequest(reason=msg)
+    elif not isValidBucketName(bucket):
+        msg = f"Invalid bucket name: {bucket}"
+        log.warn(msg)
+        raise HTTPBadRequest(reason=msg)
 
     log.info(f"DELETE group: {group_id} bucket: {bucket}")
 
@@ -287,6 +309,12 @@ async def POST_Root(request):
         bucket = params["bucket"]
     else:
         bucket = None
+
+    if not isValidBucketName(bucket):
+        msg = f"Invalid bucket name: {bucket}"
+        log.warn(msg)
+        raise HTTPBadRequest(reason=msg)
+
     if "timestamp" in params:
         try:
             timestamp = int(params["timestamp"])

--- a/hsds/link_dn.py
+++ b/hsds/link_dn.py
@@ -24,6 +24,7 @@ from aiohttp.web import json_response
 from .util.idUtil import isValidUuid
 from .util.globparser import globmatch
 from .util.linkUtil import validateLinkName, getLinkClass, isEqualLink
+from .util.domainUtil import isValidBucketName
 from .datanode_lib import get_obj_id, get_metadata_obj, save_metadata_obj
 from . import hsds_logger as log
 
@@ -101,6 +102,10 @@ async def GET_Links(request):
 
     if not bucket:
         msg = "GET_Links - no bucket param"
+        log.warn(msg)
+        raise HTTPBadRequest(reason=msg)
+    elif not isValidBucketName(bucket):
+        msg = f"Invalid bucket name: {bucket}"
         log.warn(msg)
         raise HTTPBadRequest(reason=msg)
 
@@ -186,6 +191,10 @@ async def POST_Links(request):
 
     if not bucket:
         msg = "POST_Links - no bucket param"
+        log.warn(msg)
+        raise HTTPBadRequest(reason=msg)
+    elif not isValidBucketName(bucket):
+        msg = f"Invalid bucket name: {bucket}"
         log.warn(msg)
         raise HTTPBadRequest(reason=msg)
 
@@ -316,6 +325,10 @@ async def PUT_Links(request):
         msg = "PUT_Links - no bucket provided"
         log.warn(msg)
         raise HTTPBadRequest(reason=msg)
+    elif not isValidBucketName(bucket):
+        msg = f"Invalid bucket name: {bucket}"
+        log.warn(msg)
+        raise HTTPBadRequest(reason=msg)
 
     group_json = await get_metadata_obj(app, group_id, bucket=bucket)
     if "links" not in group_json:
@@ -408,6 +421,10 @@ async def DELETE_Links(request):
 
     if not bucket:
         msg = "DELETE_Links - no bucket param"
+        log.warn(msg)
+        raise HTTPBadRequest(reason=msg)
+    elif not isValidBucketName(bucket):
+        msg = f"Invalid bucket name: {bucket}"
         log.warn(msg)
         raise HTTPBadRequest(reason=msg)
 

--- a/hsds/util/domainUtil.py
+++ b/hsds/util/domainUtil.py
@@ -304,31 +304,20 @@ def getLimits():
 
 def isValidBucketName(bucket):
     """
-    Check whether the given bucket name follows (a subset of)
-    the rules for naming buckets in Amazon S3
-    https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+    Check whether the given bucket name contains only
+    alphanumeric characters and underscores
     """
     is_valid = True
 
     if bucket is None:
         return True
 
-    # Bucket names must be between 3 (min) and 63 (max) characters long.
-    if len(bucket) < 3 or len(bucket) > 63:
+    # Bucket names must contain at least 1 character
+    if len(bucket) < 1:
         is_valid = False
 
-    # Bucket names can consist only of lowercase letters, numbers, dots (.), and hyphens (-).
-    if not re.fullmatch("[a-zA-Z0-9\\.\\-]+", bucket):
-        is_valid = False
-
-    # Bucket names must begin and end with a letter or number.
-    if not re.fullmatch("[a-zA-Z0-9]+", bucket[0]):
-        is_valid = False
-    if not re.fullmatch("[a-zA-Z0-9]+", bucket[len(bucket) - 1]):
-        is_valid = False
-
-    # Bucket names must not contain two adjacent periods.
-    if ".." in bucket:
+    # Bucket names can consist only of alphanumeric characters and underscores
+    if not re.fullmatch("[a-zA-Z0-9_]+", bucket):
         is_valid = False
 
     return is_valid

--- a/tests/unit/domain_util_test.py
+++ b/tests/unit/domain_util_test.py
@@ -129,18 +129,14 @@ class DomainUtilTest(unittest.TestCase):
         self.assertFalse(isValidBucketName("bucket\""))
         self.assertFalse(isValidBucketName("bucket "))
         self.assertFalse(isValidBucketName("bucket>"))
-        # Must begin and end with letter/number
         self.assertFalse(isValidBucketName(".bucket"))
-        self.assertFalse(isValidBucketName("bucket."))
-        self.assertFalse(isValidBucketName("-bucket"))
-        # Double periods not allowed
-        self.assertFalse(isValidBucketName("buck..et"))
+        self.assertFalse(isValidBucketName(""))
 
         self.assertTrue(isValidBucketName("bucket"))
-        self.assertTrue(isValidBucketName("buck.et"))
+        self.assertTrue(isValidBucketName("bucket_"))
         self.assertTrue(isValidBucketName("bucket1"))
-        self.assertTrue(isValidBucketName("buck-et"))
-        self.assertTrue(isValidBucketName("bucket-1.bucket1-.1"))
+        self.assertTrue(isValidBucketName("_"))
+        self.assertTrue(isValidBucketName("___1234567890___"))
 
 
 if __name__ == "__main__":

--- a/tests/unit/domain_util_test.py
+++ b/tests/unit/domain_util_test.py
@@ -19,6 +19,7 @@ from hsds.util.domainUtil import (
     isValidDomainPath,
     getBucketForDomain,
     getPathForDomain,
+    isValidBucketName
 )
 
 
@@ -119,6 +120,27 @@ class DomainUtilTest(unittest.TestCase):
         self.assertEqual(domain_path, "/home/test_user1/myfile.h5")
         bucket = getBucketForDomain(domain)
         self.assertEqual(bucket, "mybucket")
+
+    def testIsValidBucketName(self):
+        # Illegal characters
+        self.assertFalse(isValidBucketName("bucket;"))
+        self.assertFalse(isValidBucketName("bucket|"))
+        self.assertFalse(isValidBucketName("bucket&"))
+        self.assertFalse(isValidBucketName("bucket\""))
+        self.assertFalse(isValidBucketName("bucket "))
+        self.assertFalse(isValidBucketName("bucket>"))
+        # Must begin and end with letter/number
+        self.assertFalse(isValidBucketName(".bucket"))
+        self.assertFalse(isValidBucketName("bucket."))
+        self.assertFalse(isValidBucketName("-bucket"))
+        # Double periods not allowed
+        self.assertFalse(isValidBucketName("buck..et"))
+
+        self.assertTrue(isValidBucketName("bucket"))
+        self.assertTrue(isValidBucketName("buck.et"))
+        self.assertTrue(isValidBucketName("bucket1"))
+        self.assertTrue(isValidBucketName("buck-et"))
+        self.assertTrue(isValidBucketName("bucket-1.bucket1-.1"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes a security issue where bucket strings could end up on the command line when using the Azure backend. 

Not all of the [AWS bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) are enforced - only the ones that are relevant to preventing security exploits, and can be checked directly by HSDS.

Also fixed PUT_Attributes and POST_Datatype in the DN not retrieving bucket from the body.