### PR TITLE
Fix docker compose not creating multiple SNs correctly

### DIFF
--- a/admin/docker/docker-compose-internal-lb.yml
+++ b/admin/docker/docker-compose-internal-lb.yml
@@ -43,6 +43,7 @@ services:
     mem_limit: ${SN_RAM}
     environment:
       - SN_PORT=${SN_PORT}
+      - SN_CORES=${SN_CORES}
       - NODE_TYPE=sn
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}

--- a/admin/docker/docker-compose.aws.yml
+++ b/admin/docker/docker-compose.aws.yml
@@ -46,6 +46,7 @@ services:
     mem_limit: ${SN_RAM}
     environment:
       - SN_PORT=${SN_PORT}
+      - SN_CORES=${SN_CORES}
       - NODE_TYPE=sn
       - AWS_S3_GATEWAY=${AWS_S3_GATEWAY}
       - AWS_REGION=${AWS_REGION}

--- a/admin/docker/docker-compose.azure.yml
+++ b/admin/docker/docker-compose.azure.yml
@@ -40,6 +40,7 @@ services:
     mem_limit: ${SN_RAM}
     environment:
       - SN_PORT=${SN_PORT}
+      - SN_CORES=${SN_CORES}
       - NODE_TYPE=sn
       - AZURE_CONNECTION_STRING=${AZURE_CONNECTION_STRING}
       - BUCKET_NAME=${BUCKET_NAME}

--- a/admin/docker/docker-compose.posix.yml
+++ b/admin/docker/docker-compose.posix.yml
@@ -39,6 +39,7 @@ services:
     mem_limit: ${SN_RAM}
     environment:
       - SN_PORT=${SN_PORT}
+      - SN_CORES=${SN_CORES}
       - NODE_TYPE=sn
       - ROOT_DIR=/data
       - BUCKET_NAME=${BUCKET_NAME}

--- a/admin/docker/docker-compose.yml
+++ b/admin/docker/docker-compose.yml
@@ -46,6 +46,7 @@ services:
     mem_limit: ${SN_RAM}
     environment:
       - SN_PORT=${SN_PORT}
+      - SN_CORES=${SN_CORES}
       - NODE_TYPE=sn
       - AWS_S3_GATEWAY=${AWS_S3_GATEWAY}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}


### PR DESCRIPTION
Setting up HSDS through Docker with more than one SN would end up infinitely waiting for the server to be ready. 