### PR TITLE
Fix writing base64 encoded vlen data to point selection

### DIFF
--- a/hsds/chunk_crawl.py
+++ b/hsds/chunk_crawl.py
@@ -569,10 +569,14 @@ async def write_point_sel(
     log.debug("POST chunk req: " + req)
 
     num_points = len(point_list)
-    log.debug(f"write_point_sel - {num_points}")
 
     # create a numpy array with point_data
-    data_arr = jsonToArray((num_points,), dset_dtype, point_data)
+
+    # if point data was already decoded from binary, don't decode again
+    if len(point_data) > 0 and isinstance(point_data[0], np.ndarray):
+        data_arr = point_data
+    else:
+        data_arr = jsonToArray((num_points,), dset_dtype, point_data)
 
     # create a numpy array with the following type:
     #   (coord1, coord2, ...) | dset_dtype
@@ -592,8 +596,7 @@ async def write_point_sel(
             elem = (tuple(point_list[i]), data_arr[i])
         np_arr[i] = elem
 
-    # TBD - support VLEN data
-    post_data = np_arr.tobytes()
+    post_data = arrayToBytes(np_arr)
 
     # pass dset_json as query params
     params = {}

--- a/hsds/chunk_sn.py
+++ b/hsds/chunk_sn.py
@@ -385,6 +385,7 @@ async def _getRequestData(request, http_streaming=True):
             base64_data = body["value_base64"]
             base64_data = base64_data.encode("ascii")
             input_data = base64.b64decode(base64_data)
+            log.debug(f"input_data from base64: {input_data}")
         else:
             msg = "request has no value or value_base64 key in body"
             log.warn(msg)
@@ -760,7 +761,6 @@ async def PUT_Value(request):
         return resp
 
     # regular PUT_Value processing without query update
-    binary_data = None
     np_shape = []  # shape of incoming data
     bc_shape = []  # shape of broadcast array (if element_count is set)
     input_data = await _getRequestData(request, http_streaming=http_streaming)
@@ -832,12 +832,12 @@ async def PUT_Value(request):
             # fixed item size
             if len(input_data) % item_size != 0:
                 msg = f"Expected request size to be a multiple of {item_size}, "
-                msg += f"but {len(binary_data)} bytes received"
+                msg += f"but {len(input_data)} bytes received"
                 log.warn(msg)
                 raise HTTPBadRequest(reason=msg)
 
             if len(input_data) // item_size != num_elements:
-                msg = f"expected {item_size * num_elements} bytes but got {len(binary_data)}"
+                msg = f"expected {item_size * num_elements} bytes but got {len(input_data)}"
                 log.warn(msg)
                 raise HTTPBadRequest(reason=msg)
 


### PR DESCRIPTION
When base64-encoded variable-length data to a point selection, HSDS converts the received base64 directly to a numpy array of the appropriate vlen type in `PUT_Value -> _getRequestData`.  `write_point_sel`, expects the provided data to be JSON and attempts to parse it to an array again, causing an error.

This changes `write_point_sel` to check if its received data is already decoded. 