### PR TITLE
Add support for "where in" queries

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
 run_pyflakes=1
+run_docker=1
 if [ $# -gt 0 ]; then
     if [ $1 == "-h" ] || [ $1 == "--help" ]; then
-        echo "Usage: build.sh [--nolint]"
+        echo "Usage: build.sh [--nolint | --no-docker]"
         exit 1
     fi
     if [ $1 == "--nolint" ]; then
         echo "no pyflakes"
         run_pyflakes=
+    fi
+    if [ $1 == "--no-docker" ]; then
+        echo "no docker"
+        run_docker=
     fi
 fi
 
@@ -32,9 +37,9 @@ pip install --upgrade build
 echo "running build"
 python -m build
 pip install -v .
-
-command -v docker 
-if [ $? -ne 1 ]; then
+ 
+if [ $run_docker ]; then
+    command -v docker
     echo "clean stopped containers"
     docker rm -v $(docker ps -aq -f status=exited)
 

--- a/hsds/dset_lib.py
+++ b/hsds/dset_lib.py
@@ -412,10 +412,31 @@ def getParser(query, dtype):
     """ get query BooleanParser.  If query contains variables that
        arent' part of the data type, throw a HTTPBadRequest exception. """
 
+    # separate out the where clause if any
+    if query.startswith("where"):
+        where_in = query
+        expr = None
+    else:
+        n = query.find(" where ")
+        if n > 0:
+            where_in = query[(n + 1):]
+            expr = query[:n]
+        else:
+            where_in = None
+            expr = query
+
+    if where_in:
+        log.debug(f"got where in clause: {where_in}")
+        # TBD: do full syntax check on this
+
+    if not expr:
+        # just a where clause
+        return None
+
     try:
-        parser = BooleanParser(query)
+        parser = BooleanParser(expr)
     except Exception:
-        msg = f"query: {query} is not valid"
+        msg = f"query: {expr} is not valid"
         log.warn(msg)
         raise HTTPBadRequest(reason=msg)
 

--- a/hsds/util/boolparser.py
+++ b/hsds/util/boolparser.py
@@ -127,14 +127,26 @@ class BooleanParser:
     root = None
 
     def __init__(self, exp):
-        self.tokenizer = Tokenizer(exp)
-        self.tokenizer.tokenize()
-        self.parse()
+        # tbd - BooleanParser doesn't know about where clauses.
+        # For now just strip it off the query.
+        if exp.startswith("where"):
+            self.tokenizer = None
+        else:
+            n = exp.find("where")
+            if n > 0:
+                exp = exp[:n]
+
+            self.tokenizer = Tokenizer(exp)
+            self.tokenizer.tokenize()
+            self.parse()
 
     def parse(self):
         self.root = self.parseExpression()
 
     def getVariables(self):
+        if self.tokenizer is None:
+            return []
+
         return self.tokenizer.getVariables()
 
     def parseExpression(self):

--- a/hsds/util/chunkUtil.py
+++ b/hsds/util/chunkUtil.py
@@ -1310,16 +1310,12 @@ def chunkQuery(
         except ValueError:
             msg = "where elements are not compatible with field datatype"
             raise ValueError(msg)
-        log.debug(f"tbd: where_elements_arr; {where_elements_arr}")
-        log.debug(f"tbd: chunk_sel[{where_field}]: {chunk_sel[where_field]}")
         isin_mask = np.isin(chunk_sel[where_field], where_elements_arr)
-        log.debug(f"tbd: isin_arr: {isin_mask}")
 
         if not np.any(isin_mask):
             # all false
             log.debug("query - no rows found for where elements")
             return None
-        log.debug(f"tbd - isin_mask: {isin_mask}")
 
         isin_indices = np.where(isin_mask)
         if not isinstance(isin_indices, tuple):
@@ -1328,15 +1324,12 @@ def chunkQuery(
         if len(isin_indices) == 0:
             log.warn("chunkQuery - got empty tuple where in result")
             return None
-        log.debug(f"tbd: isin_indices: {isin_indices}")
 
         isin_indices = isin_indices[0]
         if not isinstance(isin_indices, np.ndarray):
             log.warn(f"expected isin_indices of ndarray but got: {type(isin_indices)}")
             return None
-        log.debug(f"tbd - isin_indices: {isin_indices}")
         nrows = isin_indices.shape[0]
-        log.debug(f"tbd - isin_indices nrows: {nrows}")
     elif eval_str:
         log.debug("no where keyword")
         isin_indices = None
@@ -1371,7 +1364,6 @@ def chunkQuery(
             return None
 
         where_indices = where_indices[0]
-        log.debug(f"tbd - where_indices: {where_indices}")
         if not isinstance(where_indices, np.ndarray):
             log.warn(f"expected where_indices of ndarray but got: {type(where_indices)}")
             return None
@@ -1380,7 +1372,6 @@ def chunkQuery(
     else:
         where_indices = None
 
-    log.debug("tbd - check isin_indices")
     if isin_indices is None:
         pass  # skip intersection
     else:
@@ -1390,7 +1381,6 @@ def chunkQuery(
         else:
             # interest the two sets of indices
             intersect = np.intersect1d(where_indices, isin_indices)
-            log.debug(f"tbd - intersect: {intersect}")
 
             nrows = intersect.shape[0]
             if nrows == 0:
@@ -1442,7 +1432,5 @@ def chunkQuery(
     index_name = dt_rsp.names[0]
     rsp_arr[index_name] = where_indices
     log.debug(f"chunkQuery returning {len(rsp_arr)} rows")
-    for i in range(len(rsp_arr)):
-        log.debug(f"   {i}: {rsp_arr[i]}")
 
     return rsp_arr

--- a/hsds/util/chunkUtil.py
+++ b/hsds/util/chunkUtil.py
@@ -57,6 +57,7 @@ def expandChunk(
         return (1,)  # just enough to store one item
 
     layout = list(layout)
+    log.debug(f"expandChunk layout: {layout} typesize: {typesize}")
     dims = shape_json["dims"]
     rank = len(dims)
     extendable_dims = 0  # number of dimensions that are extenable
@@ -79,11 +80,11 @@ def expandChunk(
         # just adjust along extendable dimensions first
         old_chunk_size = chunk_size
         for n in range(rank):
-            dim = rank - n - 1  # start from
+            dim = rank - n - 1  # start from last dim
 
             if extendable_dims > 0:
                 if maxdims[dim] == 0:
-                    # infinately extendable dimensions
+                    # infinitely extendable dimensions
                     layout[dim] *= 2
                     chunk_size = getChunkSize(layout, typesize)
                     if chunk_size > chunk_min:
@@ -113,9 +114,8 @@ def expandChunk(
                 else:
                     pass  # can't extend chunk along this dimension
         if chunk_size <= old_chunk_size:
-            # reality check to see if we'll ever break out of the while loop
-            log.warn("Unexpected error in guess_chunk size")
-
+            # stop iteration if we haven't increased the chunk size
+            log.debug("stopping expandChunk iteration")
             break
         elif chunk_size > chunk_min:
             break  # we're good
@@ -130,6 +130,7 @@ def shrinkChunk(layout, typesize, chunk_max=CHUNK_MAX, layout_class="H5D_CHUNKED
     chunk_size = getChunkSize(layout, typesize)
     if chunk_size <= chunk_max:
         return tuple(layout)  # good already
+    log.debug(f"shrinkChunk layout: {layout} typesize: {typesize}")
     rank = len(layout)
 
     while chunk_size > chunk_max:
@@ -1015,6 +1016,115 @@ def chunkWritePoints(chunk_id=None,
         chunk_arr[coord] = val  # update the point
 
 
+def _getWhereFieldName(query):
+    """
+    Get the field name for a where clause.
+    Returns None if no where statement
+    """
+    if query.startswith("where "):
+        i = len("where ")
+    else:
+        i = query.find(" where ")
+        if i > 0:
+            i += len(" where ")
+    if i < 0:
+        # no where statement
+        return None
+
+    field_name = ""
+    end_quote_char = None
+    while i < len(query):
+        ch = query[i]
+        i += 1
+        if end_quote_char and ch == end_quote_char:
+            # end of variable
+            end_quote_char = None
+            break
+        elif ch in ("'", '"'):
+            end_quote_char = ch
+            continue
+        if field_name and not ch.isalnum() and not ch == "_" and not end_quote_char:
+            # end of variable
+            break
+        if end_quote_char or ch.isalnum() or ch == "_":
+            field_name += ch
+    if not field_name:
+        # got a where keyword, but no field name
+        raise ValueError("query where with no fieldname")
+    if end_quote_char:
+        raise ValueError("unclosed quote")
+
+    return field_name
+
+
+def _getWhereElements(query):
+    """
+    Get the values from a where clause
+    """
+
+    n = query.find(" in ")
+    if n < 0:
+        raise ValueError("where query with no 'in' keyword")
+    n += 4  # advance past " in "
+    elements = []
+    i = query[n:].find("(")
+    if i < 0:
+        raise ValueError("where in query with no '(' character)")
+    i += n + 1  # advance past '('
+
+    end_quote_char = None
+    s = None
+
+    while i < len(query):
+        ch = query[i]
+        i += 1
+        if end_quote_char and ch == end_quote_char:
+            # end of variable
+            end_quote_char = None
+            if s is None:
+                s = ""
+            elements.append(s)
+            s = None
+            continue
+        if ch in ("'", '"'):
+            end_quote_char = ch
+            if s == "b":
+                # use bytes not str
+                s = b''
+            else:
+                s = ""
+            continue
+        if ch == ",":
+            if s is not None:
+                elements.append(s)
+                s = None
+            continue
+        if ch == ")":
+            if end_quote_char:
+                raise ValueError("unclosed quote in 'where in' list")
+            if s is not None:
+                elements.append(s)
+            break
+        if ch.isspace():
+            if end_quote_char:
+                if isinstance(s, bytes):
+                    ch = ch.encode('utf8')
+                s += ch
+            continue
+        # anything else, just add to our variable
+        if isinstance(s, bytes):
+            ch = ch.encode('utf8')
+        if s is None:
+            s = ch
+        else:
+            s += ch
+
+    if end_quote_char:
+        raise ValueError("unclosed quote")
+
+    return elements
+
+
 def _getEvalStr(query, arr_name, field_names):
     """
     _getEvalStr: Get eval string for given query
@@ -1032,6 +1142,21 @@ def _getEvalStr(query, arr_name, field_names):
             msg = "invalid field name"
             log.warn("Bad query: " + msg)
             raise ValueError(msg)
+
+    if query.startswith("where "):
+        # no eval, return None
+        return None
+    # strip off any where clause after the query
+    n = query.find(" where ")
+
+    where_field = None
+    if n > 0:
+        where_field = _getWhereFieldName(query)
+        log.debug(f"where field: [{where_field}]")
+        log.debug(f"query orig: {query}")
+        query = query[:n]
+        log.debug(f"query adjusted: {query}")
+
     while i < len(query):
         ch = query[i]
         if (i + 1) < len(query):
@@ -1127,7 +1252,7 @@ def chunkQuery(
     """
     Run query on chunk and selection
     """
-    msg = f"chunkQuery - chunk_id: {chunk_id} query: {query} slices: {slices}, "
+    msg = f"chunkQuery - chunk_id: {chunk_id} query: [{query}] slices: {slices}, "
     msg += f"limit: {limit} select_dt: {select_dt}"
     log.debug(msg)
 
@@ -1148,41 +1273,86 @@ def chunkQuery(
         raise ValueError(msg)
 
     if not slices:
-        slices = [
-            slice(0, dims[0], 1),
-        ]
+        slices = [slice(0, dims[0], 1), ]
     log.debug(f"chunkQuery slices: {slices}")
     if len(slices) != rank:
         msg = "Selection rank does not match shape rank"
         log.error(msg)
         raise ValueError(msg)
     slices = tuple(slices)
+    chunk_sel = chunk_arr[slices]
 
     chunk_coord = getChunkCoordinate(chunk_id, chunk_layout)
 
     # do query selection
     field_names = dset_dt.names
 
+    # get the eval str
+    eval_str = _getEvalStr(query, "chunk_sel", field_names)
+    if eval_str:
+        log.debug(f"eval_str: {eval_str}")
+    else:
+        log.debug("no eval_str")
+
+    # check for a where in statement
+    where_field = _getWhereFieldName(query)
+    if where_field:
+        log.debug(f"where_field: {where_field}")
+        if where_field not in field_names:
+            msg = f"where field {where_field} is not a member of dataset type"
+            raise ValueError(msg)
+        where_elements = _getWhereElements(query)
+        if not where_elements:
+            msg = "query: where key word with no elements"
+            raise ValueError(msg)
+        # convert to ndarray, checking that we can convert to our dtype along the way
+        try:
+            where_elements_arr = np.array(where_elements, dtype=dset_dt[where_field])
+        except ValueError:
+            msg = "where elements are not compatible with field datatype"
+            raise ValueError(msg)
+        log.debug(f"tbd: where_elements_arr; {where_elements_arr}")
+        log.debug(f"tbd: chunk_sel[{where_field}]: {chunk_sel[where_field]}")
+        isin_arr = np.isin(chunk_sel[where_field], where_elements_arr)
+        log.debug(f"tbd: isin_arr: {isin_arr}")
+
+        if not np.any(isin_arr):
+            # all false
+            log.debug("query - no rows found for where elements")
+            return None
+
+        chunk_sel = chunk_sel[isin_arr]
+        log.debug(f"tbd - chunk_sel after boolean selection: {chunk_sel}")
+
+        if len(chunk_sel) == 0:
+            log.debug("query - no elements matched where list")
+            return None
+        if not eval_str:
+            # can just return the array
+            return chunk_sel
+    elif eval_str:
+        log.debug("no where keyword")
+    else:
+        log.warn("query  - no eval and no where in, returning None")
+        return None
+
     if query_update:
-        replace_mask = [
-            None,
-        ] * len(field_names)
+        if where_field:
+            msg = "query update is not supported with where in"
+            raise ValueError(msg)
+        replace_mask = [None,] * len(field_names)
         for i in range(len(field_names)):
             field_name = field_names[i]
             if field_name in query_update:
                 replace_mask[i] = query_update[field_name]
         log.debug(f"chunkQuery - replace_mask: {replace_mask}")
-        replace_fields = [
-            None,
-        ] * len(field_names)
+        replace_fields = [None, ] * len(field_names)
         if replace_mask == replace_fields:
             msg = "chunkQuery - no fields found in query_update"
             raise ValueError(msg)
     else:
         replace_mask = None
 
-    x = chunk_arr[slices]
-    eval_str = _getEvalStr(query, "x", field_names)
     where_indices = np.where(eval(eval_str))
     if not isinstance(where_indices, tuple):
         log.warn(f"expected where_indices of tuple but got: {type(where_indices)}")
@@ -1204,7 +1374,7 @@ def chunkQuery(
         where_indices = where_indices[:limit]
         nrows = limit
 
-    where_result = x[where_indices].copy()
+    where_result = chunk_sel[where_indices].copy()
 
     if replace_mask and nrows > 0:
         log.debug(f"apply replace_mask: {replace_mask}")

--- a/tests/integ/query_test.py
+++ b/tests/integ/query_test.py
@@ -156,6 +156,7 @@ class QueryTest(unittest.TestCase):
             # check we got the expected number of results
             if expected_count is not None:
                 self.assertEqual(len(data), expected_count)
+        # end verifyQueryRsp
 
         req = self.endpoint + "/datasets/" + dset_uuid + "/value"
 
@@ -166,6 +167,17 @@ class QueryTest(unittest.TestCase):
                 kwargs["expect_bin"] = True
             else:
                 kwargs["expect_bin"] = False
+
+            # items in list
+            # TBD - needs update for chunk_dn.py to work
+            """
+            params = {"query": "where stock_symbol in (b'AAPL', b'EBAY')"}
+            rsp = self.session.get(req, params=params, headers=query_headers)
+            self.assertEqual(rsp.status_code, 200)
+            kwargs["expected_indices"] = [0, 1, 3, 4, 6, 7, 9, 10]
+            print(rsp.text)
+            verifyQueryRsp(rsp, **kwargs)
+            """
 
             # read first row with AAPL
             params = {"query": "stock_symbol == b'AAPL'", "Limit": 1}
@@ -179,7 +191,6 @@ class QueryTest(unittest.TestCase):
             rsp = self.session.get(req, params=params, headers=query_headers)
             expected_indices = (1, 4, 7, 10)
             kwargs["expected_indices"] = expected_indices
-
             verifyQueryRsp(rsp, **kwargs)
 
             # return just open and close fields

--- a/tests/integ/query_test.py
+++ b/tests/integ/query_test.py
@@ -169,15 +169,11 @@ class QueryTest(unittest.TestCase):
                 kwargs["expect_bin"] = False
 
             # items in list
-            # TBD - needs update for chunk_dn.py to work
-            """
-            params = {"query": "where stock_symbol in (b'AAPL', b'EBAY')"}
+            params = {"query": "open < 4000 where stock_symbol in (b'AAPL', b'EBAY')"}
             rsp = self.session.get(req, params=params, headers=query_headers)
             self.assertEqual(rsp.status_code, 200)
             kwargs["expected_indices"] = [0, 1, 3, 4, 6, 7, 9, 10]
-            print(rsp.text)
             verifyQueryRsp(rsp, **kwargs)
-            """
 
             # read first row with AAPL
             params = {"query": "stock_symbol == b'AAPL'", "Limit": 1}
@@ -214,10 +210,21 @@ class QueryTest(unittest.TestCase):
             kwargs["expected_indices"] = (4, 7, 10)
             verifyQueryRsp(rsp, **kwargs)
 
+            params = {"query": "where stock_symbol in (b'AAPL', b'EBAY')"}
+            rsp = self.session.get(req, params=params, headers=query_headers)
+            self.assertEqual(rsp.status_code, 200)
+            kwargs["expected_indices"] = [0, 1, 3, 4, 6, 7, 9, 10]
+            verifyQueryRsp(rsp, **kwargs)
+            params = {"query": "open < 3000 where stock_symbol in (b'AAPL', b'EBAY')"}
+            rsp = self.session.get(req, params=params, headers=query_headers)
+            self.assertEqual(rsp.status_code, 200)
+            kwargs["expected_indices"] = [6, 7, 9, 10]
+            verifyQueryRsp(rsp, **kwargs)
+
             # combine with Limit
             params["Limit"] = 2
             rsp = self.session.get(req, params=params, headers=query_headers)
-            kwargs["expected_indices"] = (4, 7)
+            kwargs["expected_indices"] = (6, 7)
             verifyQueryRsp(rsp, **kwargs)
 
             # try bad Limit


### PR DESCRIPTION
Enable dataset queries with opional "where in" syntax.
E.g.:
  "(open > 5.0) & (close < 5.0) where symbol in (b'MCD', b'KO', b'JNJ')"