### PR TITLE
set correct content_length when requesting data with field selection

### DIFF
--- a/hsds/util/hdf5dtype.py
+++ b/hsds/util/hdf5dtype.py
@@ -344,7 +344,6 @@ def getTypeItem(dt, metadata=None):
         type_info["strPad"] = "H5T_STR_NULLPAD"
     elif dt.base.kind == "U":
         # Fixed length unicode type
-        print("fixed UTF, itemsize:", dt.itemsize)
         ref_check = check_dtype(ref=dt.base)
         if ref_check is not None:
             raise TypeError("unexpected reference type")
@@ -522,6 +521,30 @@ def getItemSize(typeItem):
         for dim in dims:
             item_size *= dim
 
+    return item_size
+
+
+def getDtypeItemSize(dtype):
+    """ Return size of dtype in bytes
+        For variable length types (e.g. variable length strings),
+        return the string "H5T_VARIABLE
+    """
+    item_size = 0
+    if len(dtype) > 0:
+        # compound dtype
+        for i in range(len(dtype)):
+            sub_dt = dtype[i]
+            sub_dt_size = getDtypeItemSize(sub_dt)
+            if sub_dt_size == "H5T_VARIABLE":
+                item_size = "H5T_VARIABLE"  # return variable if any component is variable
+                break
+            item_size += sub_dt_size
+    else:
+        # primitive type
+        if dtype.metadata and "vlen" in dtype.metadata:
+            item_size = "H5T_VARIABLE"
+        else:
+            item_size = dtype.itemsize
     return item_size
 
 

--- a/tests/integ/vlen_test.py
+++ b/tests/integ/vlen_test.py
@@ -664,6 +664,8 @@ class VlenTest(unittest.TestCase):
         rsp = self.session.get(req, headers=headers_bin_rsp)
         self.assertEqual(rsp.status_code, 200)
         self.assertEqual(rsp.headers["Content-Type"], "application/octet-stream")
+        for k in rsp.headers:
+            print(f"{k}: {rsp.headers[k]}")
         data = rsp.content
         self.assertEqual(len(data), 192)
         arr_rsp = bytesToArray(data, dt_compound, [count,])

--- a/tests/unit/hdf5_dtype_test.py
+++ b/tests/unit/hdf5_dtype_test.py
@@ -484,6 +484,7 @@ class Hdf5dtypeTest(unittest.TestCase):
         dt = hdf5dtype.createDataType(typeItem)
         self.assertEqual(dt.name, "bool")
         self.assertEqual(dt.kind, "b")
+        self.assertEqual(typeSize, hdf5dtype.getDtypeItemSize(dt))
 
     def testCreateCompoundType(self):
         typeItem = {
@@ -508,11 +509,14 @@ class Hdf5dtypeTest(unittest.TestCase):
         self.assertEqual(dt.name, "void144")
         self.assertEqual(dt.kind, "V")
         self.assertEqual(len(dt.fields), 4)
+        self.assertEqual(typeSize, hdf5dtype.getDtypeItemSize(dt))
+
         dtLocation = dt[2]
         self.assertEqual(dtLocation.name, "object")
         self.assertEqual(dtLocation.kind, "O")
         self.assertEqual(check_dtype(vlen=dtLocation), bytes)
         self.assertEqual(typeSize, "H5T_VARIABLE")
+        self.assertEqual(typeSize, hdf5dtype.getDtypeItemSize(dtLocation))
 
     def testCreateCompoundInvalidFieldName(self):
         typeItem = {
@@ -619,6 +623,7 @@ class Hdf5dtypeTest(unittest.TestCase):
         self.assertEqual(dt.kind, "V")
         self.assertEqual(len(dt.fields), 3)
         self.assertEqual(typeSize, 10)
+        self.assertEqual(typeSize, hdf5dtype.getDtypeItemSize(dt))
 
     def testCreateArrayType(self):
         typeItem = {"class": "H5T_ARRAY", "base": "H5T_STD_I64LE", "dims": (3, 5)}
@@ -627,6 +632,7 @@ class Hdf5dtypeTest(unittest.TestCase):
         self.assertEqual(dt.name, "void960")
         self.assertEqual(dt.kind, "V")
         self.assertEqual(typeSize, 120)
+        self.assertEqual(typeSize, hdf5dtype.getDtypeItemSize(dt))
 
     def testCreateArrayIntegerType(self):
         typeItem = {"class": "H5T_INTEGER", "base": "H5T_STD_I64LE", "dims": (3, 5)}
@@ -663,6 +669,7 @@ class Hdf5dtypeTest(unittest.TestCase):
         self.assertTrue("a" in dt.fields.keys())
         self.assertTrue("b" in dt.fields.keys())
         self.assertEqual(typeSize, 11)
+        self.assertEqual(typeSize, hdf5dtype.getDtypeItemSize(dt))
 
     def testCompoundArrayType(self):
         typeItem = {
@@ -698,6 +705,8 @@ class Hdf5dtypeTest(unittest.TestCase):
         self.assertTrue("VALUE1" in dt.fields.keys())
         self.assertTrue("VALUE2" in dt.fields.keys())
         self.assertTrue("VALUE3" in dt.fields.keys())
+        self.assertEqual(typeSize, hdf5dtype.getDtypeItemSize(dt))
+
         dt3 = dt["VALUE3"]
         self.assertEqual(check_dtype(vlen=dt3), bytes)
 


### PR DESCRIPTION
The content_length header wasn't being set to the correct number of bytes when field selections are used.