### PR TITLE
Allow periods and hyphens in bucket names

### DIFF
--- a/hsds/util/domainUtil.py
+++ b/hsds/util/domainUtil.py
@@ -304,8 +304,7 @@ def getLimits():
 
 def isValidBucketName(bucket):
     """
-    Check whether the given bucket name contains only
-    alphanumeric characters and underscores
+    Check whether the given bucket name is valid
     """
     is_valid = True
 
@@ -316,8 +315,8 @@ def isValidBucketName(bucket):
     if len(bucket) < 1:
         is_valid = False
 
-    # Bucket names can consist only of alphanumeric characters and underscores
-    if not re.fullmatch("[a-zA-Z0-9_]+", bucket):
+    # Bucket names can consist only of alphanumeric characters, underscores, dots, and hyphens
+    if not re.fullmatch("[a-zA-Z0-9_\\.\\-]+", bucket):
         is_valid = False
 
     return is_valid

--- a/tests/unit/domain_util_test.py
+++ b/tests/unit/domain_util_test.py
@@ -129,7 +129,6 @@ class DomainUtilTest(unittest.TestCase):
         self.assertFalse(isValidBucketName("bucket\""))
         self.assertFalse(isValidBucketName("bucket "))
         self.assertFalse(isValidBucketName("bucket>"))
-        self.assertFalse(isValidBucketName(".bucket"))
         self.assertFalse(isValidBucketName(""))
 
         self.assertTrue(isValidBucketName("bucket"))
@@ -137,6 +136,12 @@ class DomainUtilTest(unittest.TestCase):
         self.assertTrue(isValidBucketName("bucket1"))
         self.assertTrue(isValidBucketName("_"))
         self.assertTrue(isValidBucketName("___1234567890___"))
+
+        self.assertTrue(isValidBucketName("bucket"))
+        self.assertTrue(isValidBucketName("buck.et"))
+        self.assertTrue(isValidBucketName("bucket1"))
+        self.assertTrue(isValidBucketName("buck-et"))
+        self.assertTrue(isValidBucketName("bucket-1.bucket1-.1"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Some NREL buckets have hyphens, so we should definitely allow those. Allowing periods make HSDS at least as permissive as AWS's bucket name rules.