### PR TITLE
update for multi-storage drivers

### DIFF
--- a/hsds/basenode.py
+++ b/hsds/basenode.py
@@ -567,6 +567,7 @@ def baseInit(node_type):
     app["start_time"] = int(time.time())  # seconds after epoch
     app["register_time"] = 0
     app["max_task_count"] = config.get("max_task_count")
+    app["storage_clients"] = {}  # storage client drivers
 
     is_standalone = config.getCmdLineArg("standalone")
 

--- a/hsds/chunk_dn.py
+++ b/hsds/chunk_dn.py
@@ -279,7 +279,12 @@ async def PUT_Chunk(request):
             log.error(msg)
             raise HTTPInternalServerError()
 
-        input_arr = bytesToArray(input_bytes, select_dt, [num_elements, ])
+        try:
+            input_arr = bytesToArray(input_bytes, select_dt, [num_elements, ])
+        except ValueError as ve:
+            log.error(f"bytesToArray threw ValueError: {ve}")
+            raise HTTPInternalServerError()
+
         if bcshape:
             input_arr = input_arr.reshape(bcshape)
             log.debug(f"broadcasting {bcshape} to mshape {mshape}")

--- a/hsds/datanode_lib.py
+++ b/hsds/datanode_lib.py
@@ -327,7 +327,6 @@ async def get_metadata_obj(app, obj_id, bucket=None):
     log.info(f"get_metadata_obj: {obj_id} bucket: {bucket}")
     if isValidDomain(obj_id):
         domain_bucket = getBucketForDomain(obj_id)
-        log.debug(f"tbd - domain_bucket: {domain_bucket}")
         if bucket and domain_bucket and bucket != domain_bucket:
             msg = f"get_metadata_obj for domain: {obj_id} but bucket param was: {bucket}"
             log.error(msg)

--- a/hsds/util/idUtil.py
+++ b/hsds/util/idUtil.py
@@ -27,7 +27,7 @@ AZURE_URI = "blob.core.windows.net/"  # preceded with "https://"
 
 
 def _getStorageProtocol(uri):
-    """ returns 's3://', 'file://', or 'https://...net/' prefix if pressent.
+    """ returns 's3://', 'file://', or 'https://...net/' prefix if present.
     If the prefix is in the form: https://myaccount.blob.core.windows.net/mycontainer
     (references Azure blob storage), return: https://myaccount.blob.core.windows.net/
     otherwise None """

--- a/hsds/util/idUtil.py
+++ b/hsds/util/idUtil.py
@@ -21,6 +21,43 @@ from aiohttp.web_exceptions import HTTPServiceUnavailable
 from .. import hsds_logger as log
 
 
+S3_URI = "s3://"
+FILE_URI = "file://"
+AZURE_URI = "blob.core.windows.net/"  # preceded with "https://"
+
+
+def _getStorageProtocol(uri):
+    """ returns 's3://', 'file://', or 'https://...net/' prefix if pressent.
+    If the prefix is in the form: https://myaccount.blob.core.windows.net/mycontainer
+    (references Azure blob storage), return: https://myaccount.blob.core.windows.net/
+    otherwise None """
+
+    if not uri:
+        protocol = None
+    elif uri.startswith(S3_URI):
+        protocol = S3_URI
+    elif uri.startswith(FILE_URI):
+        protocol = FILE_URI
+    elif uri.startswith("https://") and uri.find(AZURE_URI) > 0:
+        n = uri.find(AZURE_URI) + len(AZURE_URI)
+        protocol = uri[:n]
+    elif uri.find("://") >= 0:
+        raise ValueError(f"storage uri: {uri} not supported")
+    else:
+        protocol = None
+    return protocol
+
+
+def _getBaseName(uri):
+    """ Return the part of the URI after the storage protocol (if any) """
+
+    protocol = _getStorageProtocol(uri)
+    if not protocol:
+        return uri
+    else:
+        return uri[len(protocol):]
+
+
 def getIdHash(id):
     """Return md5 prefix based on id value"""
     m = hashlib.new("md5")
@@ -146,14 +183,19 @@ def getS3Key(id):
         Chunk ids have the chunk index added after the slash:
         "db/id[0:16]/d/id[16:32]/x_y_z
 
-    For domain id's return a key with the .domain suffix and no
-    preceeding slash
+    For domain id's:
+        Return a key with the .domain suffix and no preceeding slash.
+        For non-default buckets, use the format: <bucket_name>/s3_key
+        If the id has a storage specifier ("s3://", "file://", etc.)
+        include that along with the bucket name. e.g.: "s3://mybucket/a_folder/a_file.h5"
     """
-    if id.find("/") > 0:
+
+    base_id = _getBaseName(id)  # strip any s3://, etc.
+    if base_id.find("/") > 0:
         # a domain id
         domain_suffix = ".domain.json"
-        index = id.find("/") + 1
-        key = id[index:]
+        index = base_id.find("/") + 1
+        key = base_id[index:]
         if not key.endswith(domain_suffix):
             if key[-1] != "/":
                 key += "/"

--- a/hsds/util/s3Client.py
+++ b/hsds/util/s3Client.py
@@ -281,7 +281,7 @@ class S3Client:
 
         start_time = time.time()
         if length > 0:
-            range = f"bytes={offset} - {offset + length - 1}"
+            range = f"bytes={offset}-{offset + length - 1}"
             log.info(f"storage range request: {range}")
         log.debug(f"s3Client.get_object({bucket}/{key}) range: {range} start: {start_time}")
         session = self._app["session"]

--- a/hsds/util/s3Client.py
+++ b/hsds/util/s3Client.py
@@ -26,6 +26,8 @@ from aiohttp.web_exceptions import HTTPForbidden, HTTPBadRequest
 from .. import hsds_logger as log
 from .. import config
 
+S3_URI = "s3://"
+
 
 class S3Client:
     """
@@ -268,16 +270,20 @@ class S3Client:
         """
 
         range = ""
-        if length > 0:
-            range = f"bytes={offset} - {offset + length - 1}"
-            log.info(f"storage range request: {range}")
 
         if not bucket:
             log.error("get_object - bucket not set")
             raise HTTPInternalServerError()
 
+        # remove s3:// prefix if present
+        if bucket.startswith(S3_URI):
+            bucket = bucket[len(S3_URI):]
+
         start_time = time.time()
-        log.debug(f"s3Client.get_object({bucket}/{key}) start: {start_time}")
+        if length > 0:
+            range = f"bytes={offset} - {offset + length - 1}"
+            log.info(f"storage range request: {range}")
+        log.debug(f"s3Client.get_object({bucket}/{key}) range: {range} start: {start_time}")
         session = self._app["session"]
         self._renewToken()
         kwargs = self._get_client_kwargs()
@@ -342,6 +348,10 @@ class S3Client:
             log.error("put_object - bucket not set")
             raise HTTPInternalServerError()
 
+        # remove s3:// prefix if present
+        if bucket.startswith(S3_URI):
+            bucket = bucket[len(S3_URI):]
+
         start_time = time.time()
         log.debug(f"s3Client.put_object({bucket}/{key} start: {start_time}")
         session = self._app["session"]
@@ -391,9 +401,14 @@ class S3Client:
 
     async def delete_object(self, key, bucket=None):
         """Deletes the object at the given key"""
+
         if not bucket:
             log.error("delete_object - bucket not set")
             raise HTTPInternalServerError()
+
+        # remove s3:// prefix if present
+        if bucket.startswith(S3_URI):
+            bucket = bucket[len(S3_URI):]
 
         start_time = time.time()
         log.debug(f"s3Client.delete_object({bucket}/{key} start: {start_time}")
@@ -437,6 +452,11 @@ class S3Client:
         if not bucket:
             log.error("is_object - bucket not set")
             raise HTTPInternalServerError()
+
+        # remove s3:// prefix if present
+        if bucket.startswith(S3_URI):
+            bucket = bucket[len(S3_URI):]
+
         start_time = time.time()
         found = False
         session = self._app["session"]
@@ -473,6 +493,15 @@ class S3Client:
 
     async def get_key_stats(self, key, bucket=None):
         """Get ETag, size, and last modified time for given object"""
+
+        if not bucket:
+            log.error("get_key_stats - bucket not set")
+            raise HTTPInternalServerError()
+
+        # remove s3:// prefix if present
+        if bucket.startswith(S3_URI):
+            bucket = bucket[len(S3_URI):]
+
         start_time = time.time()
         session = self._app["session"]
         self._renewToken()
@@ -577,6 +606,11 @@ class S3Client:
         if not bucket:
             log.error("list_keys - bucket not set")
             raise HTTPInternalServerError()
+
+        # remove s3:// prefix if present
+        if bucket.startswith(S3_URI):
+            bucket = bucket[len(S3_URI):]
+
         msg = f"list_keys('{prefix}','{deliminator}','{suffix}', "
         msg += f"include_stats={include_stats}, "
         msg += f"callback {'set' if callback is not None else 'not set'}"

--- a/runall.sh
+++ b/runall.sh
@@ -143,19 +143,9 @@ fi
 
 [[ -z ${HSDS_ENDPOINT} ]] && echo "HSDS_ENDPOINT is not set" && exit 1
 
-if [[ ${AWS_S3_GATEWAY} ]]; then
-  COMPOSE_FILE="admin/docker/docker-compose.aws.yml"
-  echo "AWS_S3_GATEWAY set, using ${BUCKET_NAME} S3 Bucket (verify that this bucket exists)"
-elif [[ ${AZURE_CONNECTION_STRING} ]]; then
-  COMPOSE_FILE="admin/docker/docker-compose.azure.yml"
-  echo "AZURE_CONNECTION_STRING set, using ${BUCKET_NAME} Azure Storage Container (verify that the container exsits)"
-else 
+if [[ ${ROOT_DIR} ]]; then 
   COMPOSE_FILE="admin/docker/docker-compose.posix.yml"
-  echo "no AWS or AZURE env set, using POSIX storage"
-  if [[ -z ${ROOT_DIR} ]]; then
-    export ROOT_DIR=$PWD/data
-    echo "no ROOT_DIR env set, using $ROOT_DIR directory for storage"
-  fi
+  echo "ROOT_DIR set, using POSIX storage"
   if [[ ! -d ${ROOT_DIR} ]]; then
       echo "creating directory ${ROOT_DIR}"
       mkdir ${ROOT_DIR}
@@ -164,6 +154,15 @@ else
       echo "creating directory ${ROOT_DIR}/${BUCKET_NAME}"
       mkdir ${ROOT_DIR}/${BUCKET_NAME}
   fi
+elif [[ ${AWS_S3_GATEWAY} ]]; then
+  COMPOSE_FILE="admin/docker/docker-compose.aws.yml"
+  echo "AWS_S3_GATEWAY set, using ${BUCKET_NAME} S3 Bucket (verify that this bucket exists)"
+elif [[ ${AZURE_CONNECTION_STRING} ]]; then
+  COMPOSE_FILE="admin/docker/docker-compose.azure.yml"
+  echo "AZURE_CONNECTION_STRING set, using ${BUCKET_NAME} Azure Storage Container (verify that the container exsits)"
+else
+  echo "no storage setting defined (set at least one of ROOT_DIR, AWS_S3_GATEWAY or AZURE_CONNECTION_STRING)"
+  exit 1
 fi
  
 if [[ -z $AWS_IAM_ROLE ]] && [[ $AWS_S3_GATEWAY ]]; then

--- a/tests/integ/pointsel_test.py
+++ b/tests/integ/pointsel_test.py
@@ -516,7 +516,7 @@ class PointSelTest(unittest.TestCase):
         root_uuid = rspJson["root"]
 
         # create dataset fodr /g1/g1.1/dset1.1.2
-        s3path = "s3://" + hdf5_sample_bucket + "/data/hdf5test" + "/tall.h5"
+        s3path = hdf5_sample_bucket + "/data/hdf5test" + "/tall.h5"
         data = {"type": "H5T_STD_I32BE", "shape": 20}
         layout = {
             "class": "H5D_CONTIGUOUS_REF",
@@ -578,7 +578,6 @@ class PointSelTest(unittest.TestCase):
             msg = f"s3object: {s3path} not found, "
             msg += "skipping point read chunk reference contiguous test"
             print(msg)
-
             return
 
         self.assertEqual(rsp.status_code, 200)
@@ -586,9 +585,8 @@ class PointSelTest(unittest.TestCase):
         self.assertTrue("value" in rspJson)
         ret_value = rspJson["value"]
         self.assertEqual(len(ret_value), len(points))
-        self.assertEqual(
-            ret_value, points
-        )  # get back the points since the dataset in the range 0-20
+        self.assertEqual(ret_value, points)
+        # get back the points since the dataset in the range 0-20
 
         # do a point selection read on dset22
         req = self.endpoint + "/datasets/" + dset22_id + "/value"
@@ -610,7 +608,7 @@ class PointSelTest(unittest.TestCase):
             print("hdf5_sample_bucket config not set, skipping testChunkedRefDataset")
             return
 
-        s3path = "s3://" + hdf5_sample_bucket + "/data/hdf5test" + "/snp500.h5"
+        s3path = hdf5_sample_bucket + "/data/hdf5test" + "/snp500.h5"
         SNP500_ROWS = 3207353
 
         snp500_json = helper.getHDF5JSON("snp500.json")
@@ -618,17 +616,13 @@ class PointSelTest(unittest.TestCase):
             print("snp500.json file not found, skipping testPostChunkedRefDataset")
             return
 
-        if "snp500.h5" not in snp500_json:
-            self.assertTrue(False)
+        self.assertTrue("snp500.h5" in snp500_json)
 
-        chunk_dims = [
-            60000,
-        ]  # chunk layout used in snp500.h5 file
+        chunk_dims = [60000, ]  # chunk layout used in snp500.h5 file
 
         chunk_info = snp500_json["snp500.h5"]
         dset_info = chunk_info["/dset"]
-        if "byteStreams" not in dset_info:
-            self.assertTrue(False)
+        self.assertTrue("byteStreams" in dset_info)
         byteStreams = dset_info["byteStreams"]
 
         # construct map of chunks
@@ -675,9 +669,7 @@ class PointSelTest(unittest.TestCase):
 
         data = {
             "type": datatype,
-            "shape": [
-                SNP500_ROWS,
-            ],
+            "shape": [SNP500_ROWS, ],
         }
         layout = {
             "class": "H5D_CHUNKED_REF",
@@ -731,7 +723,7 @@ class PointSelTest(unittest.TestCase):
             print(msg)
             return
 
-        s3path = "s3://" + hdf5_sample_bucket + "/data/hdf5test" + "/snp500.h5"
+        s3path = hdf5_sample_bucket + "/data/hdf5test" + "/snp500.h5"
         SNP500_ROWS = 3207353
 
         snp500_json = helper.getHDF5JSON("snp500.json")
@@ -739,16 +731,14 @@ class PointSelTest(unittest.TestCase):
             print("snp500.json file not found, skipping testChunkedRefDataset")
             return
 
-        if "snp500.h5" not in snp500_json:
-            self.assertTrue(False)
+        self.assertTrue("snp500.h5" in snp500_json)
 
         chunk_dims = [60000,]  # chunk layout used in snp500.h5 file
         num_chunks = (SNP500_ROWS // chunk_dims[0]) + 1
 
         chunk_info = snp500_json["snp500.h5"]
         dset_info = chunk_info["/dset"]
-        if "byteStreams" not in dset_info:
-            self.assertTrue(False)
+        self.assertTrue("byteStreams" in dset_info)
         byteStreams = dset_info["byteStreams"]
 
         self.assertEqual(len(byteStreams), num_chunks)
@@ -777,9 +767,7 @@ class PointSelTest(unittest.TestCase):
         chunkinfo_type = {"class": "H5T_COMPOUND", "fields": fields}
         req = self.endpoint + "/datasets"
         # Store 40 chunk locations
-        chunkinfo_dims = [
-            num_chunks,
-        ]
+        chunkinfo_dims = [num_chunks, ]
         payload = {"type": chunkinfo_type, "shape": chunkinfo_dims}
         req = self.endpoint + "/datasets"
         rsp = self.session.post(req, data=json.dumps(payload), headers=headers)
@@ -832,9 +820,7 @@ class PointSelTest(unittest.TestCase):
 
         data = {
             "type": datatype,
-            "shape": [
-                SNP500_ROWS,
-            ],
+            "shape": [SNP500_ROWS, ],
         }
         layout = {
             "class": "H5D_CHUNKED_REF_INDIRECT",

--- a/tests/integ/query_test.py
+++ b/tests/integ/query_test.py
@@ -273,7 +273,7 @@ class QueryTest(unittest.TestCase):
             )
             return
 
-        s3path = "s3://" + hdf5_sample_bucket + "/data/hdf5test" + "/snp500.h5"
+        s3path = hdf5_sample_bucket + "/data/hdf5test" + "/snp500.h5"
         SNP500_ROWS = 3207353
 
         snp500_json = helper.getHDF5JSON("snp500.json")
@@ -281,16 +281,14 @@ class QueryTest(unittest.TestCase):
             print("snp500.json file not found, skipping testChunkedRefDataset")
             return
 
-        if "snp500.h5" not in snp500_json:
-            self.assertTrue(False)
+        self.assertTrue("snp500.h5" in snp500_json)
 
         chunk_dims = [60000, ]  # chunk layout used in snp500.h5 file
         num_chunks = (SNP500_ROWS // chunk_dims[0]) + 1
 
         chunk_info = snp500_json["snp500.h5"]
         dset_info = chunk_info["/dset"]
-        if "byteStreams" not in dset_info:
-            self.assertTrue(False)
+        self.assertTrue("byteStreams" in dset_info)
         byteStreams = dset_info["byteStreams"]
 
         self.assertEqual(len(byteStreams), num_chunks)
@@ -319,9 +317,7 @@ class QueryTest(unittest.TestCase):
         chunkinfo_type = {"class": "H5T_COMPOUND", "fields": fields}
         req = self.endpoint + "/datasets"
         # Store 40 chunk locations
-        chunkinfo_dims = [
-            num_chunks,
-        ]
+        chunkinfo_dims = [num_chunks, ]
         payload = {"type": chunkinfo_type, "shape": chunkinfo_dims}
         req = self.endpoint + "/datasets"
         rsp = self.session.post(req, data=json.dumps(payload), headers=headers)
@@ -374,9 +370,7 @@ class QueryTest(unittest.TestCase):
 
         data = {
             "type": datatype,
-            "shape": [
-                SNP500_ROWS,
-            ],
+            "shape": [SNP500_ROWS, ],
         }
         layout = {
             "class": "H5D_CHUNKED_REF_INDIRECT",

--- a/tests/integ/vlen_test.py
+++ b/tests/integ/vlen_test.py
@@ -664,8 +664,6 @@ class VlenTest(unittest.TestCase):
         rsp = self.session.get(req, headers=headers_bin_rsp)
         self.assertEqual(rsp.status_code, 200)
         self.assertEqual(rsp.headers["Content-Type"], "application/octet-stream")
-        for k in rsp.headers:
-            print(f"{k}: {rsp.headers[k]}")
         data = rsp.content
         self.assertEqual(len(data), 192)
         arr_rsp = bytesToArray(data, dt_compound, [count,])

--- a/tests/unit/domain_util_test.py
+++ b/tests/unit/domain_util_test.py
@@ -19,7 +19,7 @@ from hsds.util.domainUtil import (
     isValidDomainPath,
     getBucketForDomain,
     getPathForDomain,
-    isValidBucketName
+    isValidBucketName,
 )
 
 
@@ -52,7 +52,11 @@ class DomainUtilTest(unittest.TestCase):
         for domain in invalid_domains:
             self.assertFalse(isValidDomain(domain))
 
-        valid_domains = ("/gov/nasa/nex", "/home")
+        azure_path = "https://myaccount.blob.core.windows.net//home"
+        s3_path = "s3://mybucket/home"
+        file_path = "file://mybucket/home"
+
+        valid_domains = ("/gov/nasa/nex", "/home", s3_path, file_path, azure_path)
         for domain in valid_domains:
             self.assertTrue(isValidDomain(domain))
 
@@ -121,6 +125,24 @@ class DomainUtilTest(unittest.TestCase):
         bucket = getBucketForDomain(domain)
         self.assertEqual(bucket, "mybucket")
 
+        domain = "s3://nasaeos/gov/nasa/nex/climate.h5"
+        domain_path = getPathForDomain(domain)
+        self.assertEqual("/gov/nasa/nex/climate.h5", domain_path)
+        bucket = getBucketForDomain(domain)
+        self.assertEqual(bucket, "s3://nasaeos")
+
+        domain = "file://nasaeos/gov/nasa/nex/climate.h5"
+        domain_path = getPathForDomain(domain)
+        self.assertEqual("/gov/nasa/nex/climate.h5", domain_path)
+        bucket = getBucketForDomain(domain)
+        self.assertEqual(bucket, "file://nasaeos")
+
+        domain = "https://myaccount.blob.core.windows.net/nasaeos/gov/nasa/nex/climate.h5"
+        domain_path = getPathForDomain(domain)
+        self.assertEqual("/gov/nasa/nex/climate.h5", domain_path)
+        bucket = getBucketForDomain(domain)
+        self.assertEqual(bucket, "https://myaccount.blob.core.windows.net/nasaeos")
+
     def testIsValidBucketName(self):
         # Illegal characters
         self.assertFalse(isValidBucketName("bucket;"))
@@ -130,6 +152,7 @@ class DomainUtilTest(unittest.TestCase):
         self.assertFalse(isValidBucketName("bucket "))
         self.assertFalse(isValidBucketName("bucket>"))
         self.assertFalse(isValidBucketName(""))
+        self.assertFalse(isValidBucketName("s3:/mybucket"))
 
         self.assertTrue(isValidBucketName("bucket"))
         self.assertTrue(isValidBucketName("bucket_"))
@@ -142,6 +165,9 @@ class DomainUtilTest(unittest.TestCase):
         self.assertTrue(isValidBucketName("bucket1"))
         self.assertTrue(isValidBucketName("buck-et"))
         self.assertTrue(isValidBucketName("bucket-1.bucket1-.1"))
+
+        self.assertTrue(isValidBucketName("s3://mybucket"))
+        self.assertTrue(isValidBucketName("file://mybucket"))
 
 
 if __name__ == "__main__":

--- a/tests/unit/id_util_test.py
+++ b/tests/unit/id_util_test.py
@@ -43,38 +43,78 @@ class IdUtilTest(unittest.TestCase):
             pass  # expected
 
     def testIsValidUuid(self):
-        group_id = "g-314d61b8-9954-11e6-a733-3c15c2da029e"
-        dataset_id = "d-4c48f3ae-9954-11e6-a3cd-3c15c2da029e"
-        ctype_id = "t-8c785f1c-9953-11e6-9bc2-0242ac110005"
-        chunk_id = "c-8c785f1c-9953-11e6-9bc2-0242ac110005_7_2"
+        group1_id = "g-314d61b8-9954-11e6-a733-3c15c2da029e"      # orig schema
+        group2_id = "g-314d61b8-995411e6-a733-3c15c2-da029e"
+        root_id = "g-f9aaa28e-d42e10e5-7122-2a065c-a6986d"
+        dataset1_id = "d-4c48f3ae-9954-11e6-a3cd-3c15c2da029e"    # orig schema
+        dataset2_id = "d-4c48f3ae-995411e6-a3cd-3c15c2-da029e"
+        ctype1_id = "t-8c785f1c-9953-11e6-9bc2-0242ac110005"      # orig schema
+        ctype2_id = "t-8c785f1c-995311e6-9bc2-0242ac-110005"
+        chunk1_id = "c-8c785f1c-9953-11e6-9bc2-0242ac110005_7_2"  # orig schema
+        chunk2_id = "c-8c785f1c-995311e6-9bc2-0242ac-110005_7_2"
         domain_id = "mybucket/bob/mydata.h5"
-        valid_ids = (group_id, dataset_id, ctype_id, chunk_id, domain_id)
+        s3_domain_id = "s3://mybucket/bob/mydata.h5"
+        file_domain_id = "file://mybucket/bob/mydata.h5"
+        azure_domain_id = "https://myaccount.blob.core.windows.net/mybucket/bob/mydata.h5"
+        valid_id_map = {
+            group1_id: "a49be-g-314d61b8-9954-11e6-a733-3c15c2da029e",
+            group2_id: "db/314d61b8-995411e6/g/a733-3c15c2-da029e/.group.json",
+            dataset1_id: "26928-d-4c48f3ae-9954-11e6-a3cd-3c15c2da029e",
+            dataset2_id: "db/4c48f3ae-995411e6/d/a3cd-3c15c2-da029e/.dataset.json",
+            ctype1_id: "5a9cf-t-8c785f1c-9953-11e6-9bc2-0242ac110005",
+            ctype2_id: "db/8c785f1c-995311e6/t/9bc2-0242ac-110005/.datatype.json",
+            chunk1_id: "dc4ce-c-8c785f1c-9953-11e6-9bc2-0242ac110005_7_2",
+            chunk2_id: "db/8c785f1c-995311e6/d/9bc2-0242ac-110005/7_2",
+            domain_id: "bob/mydata.h5/.domain.json",
+            s3_domain_id: "bob/mydata.h5/.domain.json",
+            file_domain_id: "bob/mydata.h5/.domain.json",
+            azure_domain_id: "bob/mydata.h5/.domain.json", }
+
         bad_ids = ("g-1e76d862", "/bob/mydata.h5")
 
-        self.assertTrue(isValidUuid(group_id))
-        self.assertFalse(isSchema2Id(group_id))
-        self.assertTrue(isValidUuid(group_id, obj_class="Group"))
-        self.assertTrue(isValidUuid(group_id, obj_class="group"))
-        self.assertTrue(isValidUuid(group_id, obj_class="groups"))
-        self.assertTrue(isValidUuid(dataset_id, obj_class="datasets"))
-        self.assertFalse(isSchema2Id(dataset_id))
-        self.assertTrue(isValidUuid(ctype_id, obj_class="datatypes"))
-        self.assertFalse(isSchema2Id(ctype_id))
-        self.assertTrue(isValidUuid(chunk_id, obj_class="chunks"))
-        self.assertFalse(isSchema2Id(chunk_id))
-        validateUuid(group_id)
+        self.assertTrue(isValidUuid(group1_id))
+        self.assertFalse(isSchema2Id(group1_id))
+        self.assertTrue(isValidUuid(group1_id, obj_class="Group"))
+        self.assertTrue(isValidUuid(group1_id, obj_class="group"))
+        self.assertTrue(isValidUuid(group1_id, obj_class="groups"))
+        self.assertTrue(isSchema2Id(root_id))
+        self.assertTrue(isValidUuid(root_id, obj_class="Group"))
+        self.assertTrue(isValidUuid(root_id, obj_class="group"))
+        self.assertTrue(isValidUuid(root_id, obj_class="groups"))
+        self.assertTrue(isRootObjId(root_id))
+        self.assertTrue(isValidUuid(dataset1_id, obj_class="datasets"))
+        self.assertFalse(isSchema2Id(dataset1_id))
+        self.assertTrue(isValidUuid(ctype1_id, obj_class="datatypes"))
+        self.assertFalse(isSchema2Id(ctype1_id))
+        self.assertTrue(isValidUuid(chunk1_id, obj_class="chunks"))
+        self.assertFalse(isSchema2Id(chunk1_id))
+        self.assertTrue(isValidUuid(group2_id))
+        self.assertTrue(isSchema2Id(group2_id))
+        self.assertTrue(isValidUuid(group2_id, obj_class="Group"))
+        self.assertTrue(isValidUuid(group2_id, obj_class="group"))
+        self.assertTrue(isValidUuid(group2_id, obj_class="groups"))
+        self.assertFalse(isRootObjId(group2_id))
+        self.assertTrue(isValidUuid(dataset2_id, obj_class="datasets"))
+        self.assertTrue(isSchema2Id(dataset2_id))
+        self.assertTrue(isValidUuid(ctype2_id, obj_class="datatypes"))
+        self.assertTrue(isSchema2Id(ctype2_id))
+        self.assertTrue(isValidUuid(chunk2_id, obj_class="chunks"))
+        self.assertTrue(isSchema2Id(chunk2_id))
+        validateUuid(group1_id)
         try:
-            isRootObjId(group_id)
+            isRootObjId(group1_id)
             self.assertTrue(False)
         except ValueError:
             # only works for v2 schema
             pass  # expected
 
-        for item in valid_ids:
+        for item in valid_id_map:
             self.assertTrue(isObjId(item))
             s3key = getS3Key(item)
             self.assertTrue(s3key[0] != "/")
             self.assertTrue(isS3ObjKey(s3key))
+            expected = valid_id_map[item]
+            self.assertEqual(s3key, expected)
             if item.find("/") > 0:
                 continue  # bucket name gets lost when domain ids get converted to s3keys
             objid = getObjId(s3key)


### PR DESCRIPTION
This PR enables HSDS to support different storage back ends (posix, s3, azure blob) in the same running instance.
If the bucket query parameter is pre-appended with a storage specifier, the corresponding driver will be used for reads and writes.
Currently supported prefixes are:

- "s3://" - aws s3
- "file://" - posix 
- "https://account_name>.blob.windows.net/" - azure  blob storage

If no prefix is used, the default driver will be used.  Where default is the first one meeting the given precondition from this list:

- "file://" - if root_dir config is set
- "s3://" - if aws_s3_gateway is set
- "https....net/" - if azure_connection_string is set
- "file://" - if none of the above apply
