### PR TITLE
Return internal server error on failed hyperslab write

### DIFF
--- a/hsds/chunk_sn.py
+++ b/hsds/chunk_sn.py
@@ -635,7 +635,8 @@ async def _doHyperslabWrite(app,
 
     if crawler_status not in (200, 201):
         msg = f"crawler failed for page: {page_number} with status: {crawler_status}"
-        log.warn(msg)
+        log.error(msg)
+        raise HTTPInternalServerError()
     else:
         log.info("crawler write_chunk_hyperslab successful")
 

--- a/tests/integ/vlen_test.py
+++ b/tests/integ/vlen_test.py
@@ -711,9 +711,12 @@ class VlenTest(unittest.TestCase):
                 # strings are showing up as bytes in the response
                 self.assertEqual(req_item, rsp_item.decode())
 
-    def testPutVLenUTF8(self):
+    def testPutVlenVlenError(self):
         # Test PUT value for 1d dataset with vlen seq of vlen utf-8 strings
-        print("testPutVLenUTF8", self.base_domain)
+        # HSDS does not currently support this datatype, but previous versions
+        # of HSDS crashed when a request contained them. This test is to
+        # ensure that HSDS still responds successfully with an error.
+        print("testPutVlenVlenError", self.base_domain)
 
         headers = helper.getRequestHeaders(domain=self.base_domain)
         req = self.endpoint + "/"
@@ -758,6 +761,11 @@ class VlenTest(unittest.TestCase):
         payload = {"value": data}
         req = self.endpoint + "/datasets/" + dset_uuid + "/value"
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
+        self.assertTrue(rsp.status_code >= 400)
+
+        # Check that HSDS still responds to requests by getting the root
+        req = self.endpoint + "/"
+        rsp = self.session.get(req, headers=headers)
         self.assertEqual(rsp.status_code, 200)
 
 


### PR DESCRIPTION
- Remove `testPutVLenUTF8`, since the case it was testing (sequence of variable-length strings) isn't supported by HSDS.
- `_doHyperslabWrite` now causes the client to receive an internal server error if it fails, instead of silently failing and still returning 200.