### PR TITLE
Fix inaccurate creation order on Windows

### DIFF
--- a/hsds/async_lib.py
+++ b/hsds/async_lib.py
@@ -10,7 +10,6 @@
 # request a copy from help@hdfgroup.org.                                     #
 ##############################################################################
 
-import time
 import hashlib
 import numpy as np
 from aiohttp.client_exceptions import ClientError
@@ -23,7 +22,7 @@ from .util.hdf5dtype import getItemSize, createDataType
 from .util.arrayUtil import getNumElements, bytesToArray
 from .util.dsetUtil import getHyperslabSelection, getFilterOps, getChunkDims, getFilters
 from .util.dsetUtil import getDatasetLayoutClass, getDatasetLayout, getShapeDims
-
+from .util.timeUtil import getNow
 from .util.storUtil import getStorKeys, putStorJSONObj, getStorJSONObj
 from .util.storUtil import deleteStorObj, getStorBytes, isStorObj
 from . import hsds_logger as log
@@ -383,7 +382,7 @@ async def scanRoot(app, rootid, update=False, bucket=None):
     results["logical_bytes"] = 0
     results["checksums"] = {}  # map of objid to checksums
     results["bucket"] = bucket
-    results["scan_start"] = time.time()
+    results["scan_start"] = getNow(app)
 
     app["scanRoot_results"] = results
     app["scanRoot_keyset"] = set()
@@ -438,7 +437,7 @@ async def scanRoot(app, rootid, update=False, bucket=None):
     # free up memory used by the checksums
     del results["checksums"]
 
-    results["scan_complete"] = time.time()
+    results["scan_complete"] = getNow(app)
 
     if update:
         # write .info object back to S3

--- a/hsds/basenode.py
+++ b/hsds/basenode.py
@@ -565,6 +565,7 @@ def baseInit(node_type):
     app["node_number"] = -1
     app["node_type"] = node_type
     app["start_time"] = int(time.time())  # seconds after epoch
+    app["start_time_relative"] = time.perf_counter()  # high precision time
     app["register_time"] = 0
     app["max_task_count"] = config.get("max_task_count")
     app["storage_clients"] = {}  # storage client drivers

--- a/hsds/ctype_dn.py
+++ b/hsds/ctype_dn.py
@@ -13,7 +13,6 @@
 # data node of hsds cluster
 #
 
-import time
 
 from aiohttp.web_exceptions import HTTPBadRequest, HTTPNotFound
 from aiohttp.web_exceptions import HTTPInternalServerError
@@ -23,6 +22,7 @@ from .util.idUtil import isValidUuid, validateUuid
 from .datanode_lib import get_obj_id, get_metadata_obj, save_metadata_obj
 from .datanode_lib import delete_metadata_obj, check_metadata_obj
 from .util.domainUtil import isValidBucketName
+from .util.timeUtil import getNow
 from . import hsds_logger as log
 
 
@@ -121,7 +121,7 @@ async def POST_Datatype(request):
     type_json = body["type"]
 
     # ok - all set, create committed type obj
-    now = time.time()
+    now = getNow(app)
 
     log.info(f"POST_datatype, typejson: {type_json}")
 

--- a/hsds/domain_dn.py
+++ b/hsds/domain_dn.py
@@ -13,13 +13,13 @@
 # data node of hsds cluster
 #
 
-import time
 from aiohttp.web_exceptions import HTTPConflict, HTTPInternalServerError
 from aiohttp.web import json_response
 
 from .util.authUtil import getAclKeys
 from .util.domainUtil import isValidDomain, getBucketForDomain
 from .util.idUtil import validateInPartition
+from .util.timeUtil import getNow
 from .datanode_lib import get_metadata_obj, save_metadata_obj
 from .datanode_lib import delete_metadata_obj, check_metadata_obj
 from . import hsds_logger as log
@@ -131,7 +131,7 @@ async def PUT_Domain(request):
         log.info("no root id, creating folder")
     domain_json["owner"] = body_json["owner"]
     domain_json["acls"] = body_json["acls"]
-    now = time.time()
+    now = getNow(app)
     domain_json["created"] = now
     domain_json["lastModified"] = now
 
@@ -213,7 +213,7 @@ async def PUT_ACL(request):
     acls[acl_username] = acl
 
     # update the timestamp
-    now = time.time()
+    now = getNow(app)
     domain_json["lastModified"] = now
 
     # write back to S3

--- a/hsds/domain_sn.py
+++ b/hsds/domain_sn.py
@@ -16,7 +16,6 @@
 import asyncio
 import json
 import os.path as op
-import time
 
 from aiohttp.web_exceptions import HTTPBadRequest, HTTPForbidden, HTTPNotFound
 from aiohttp.web_exceptions import HTTPGone, HTTPInternalServerError
@@ -37,6 +36,7 @@ from .util.domainUtil import getPathForDomain, getLimits
 from .util.storUtil import getStorKeys, getCompressors
 from .util.boolparser import BooleanParser
 from .util.globparser import globmatch
+from .util.timeUtil import getNow
 from .servicenode_lib import getDomainJson, getObjectJson, getObjectIdByPath
 from .servicenode_lib import getRootInfo, checkBucketAccess, doFlush, getDomainResponse
 from .basenode import getVersion
@@ -901,7 +901,7 @@ async def PUT_Domain(request):
             post_params = {"timestamp": 0}  # have scan run immediately
             if bucket:
                 post_params["bucket"] = bucket
-            req_send_time = time.time()
+            req_send_time = getNow(app)
             await http_post(app, notify_req, data={}, params=post_params)
 
             # Poll until the scan_complete time is greater than
@@ -913,7 +913,7 @@ async def PUT_Domain(request):
                 if scan_time > req_send_time:
                     log.info(f"scan complete for root: {root_id}")
                     break
-                if time.time() - req_send_time > MAX_WAIT_TIME:
+                if getNow(app) - req_send_time > MAX_WAIT_TIME:
                     log.warn(f"scan failed to complete in {MAX_WAIT_TIME} seconds for {root_id}")
                     raise HTTPServiceUnavailable()
                 log.debug(f"do_rescan sleeping for {RESCAN_SLEEP_TIME}s")

--- a/hsds/dset_dn.py
+++ b/hsds/dset_dn.py
@@ -13,7 +13,6 @@
 # data node of hsds cluster
 #
 
-import time
 from aiohttp.web_exceptions import HTTPBadRequest, HTTPNotFound, HTTPConflict
 from aiohttp.web_exceptions import HTTPInternalServerError
 from aiohttp.web import json_response
@@ -21,6 +20,7 @@ from aiohttp.web import json_response
 
 from .util.idUtil import isValidUuid, validateUuid
 from .util.domainUtil import isValidBucketName
+from .util.timeUtil import getNow
 from .datanode_lib import get_obj_id, check_metadata_obj, get_metadata_obj
 from .datanode_lib import save_metadata_obj, delete_metadata_obj
 from . import hsds_logger as log
@@ -132,7 +132,7 @@ async def POST_Dataset(request):
         layout = body["layout"]  # client specified chunk layout
 
     # ok - all set, create committed type obj
-    now = int(time.time())
+    now = getNow(app)
 
     log.debug(f"POST_dataset typejson: {type_json}, shapejson: {shape_json}")
 

--- a/hsds/group_dn.py
+++ b/hsds/group_dn.py
@@ -13,7 +13,6 @@
 # data node of hsds cluster
 #
 
-import time
 import asyncio
 
 from aiohttp.web_exceptions import HTTPBadRequest, HTTPInternalServerError
@@ -22,6 +21,7 @@ from aiohttp.web import json_response
 
 from .util.idUtil import isValidUuid, isSchema2Id, isRootObjId, getRootObjId
 from .util.domainUtil import isValidBucketName
+from .util.timeUtil import getNow
 from .datanode_lib import get_obj_id, check_metadata_obj, get_metadata_obj
 from .datanode_lib import save_metadata_obj, delete_metadata_obj
 from . import hsds_logger as log
@@ -121,7 +121,7 @@ async def POST_Group(request):
         raise HTTPInternalServerError()
 
     # ok - all set, create group obj
-    now = time.time()
+    now = getNow(app)
 
     group_json = {
         "id": group_id,
@@ -188,7 +188,7 @@ async def PUT_Group(request):
         log.error(f"Expected root id for flush but got: {root_id}")
         raise HTTPInternalServerError()
 
-    flush_start = time.time()
+    flush_start = getNow(app)
     flush_set = set()
     dirty_ids = app["dirty_ids"]
 
@@ -204,7 +204,7 @@ async def PUT_Group(request):
     log.debug(f"flushop - waiting on {len(flush_set)} items")
 
     if len(flush_set) > 0:
-        while time.time() - flush_start < flush_timeout:
+        while getNow(app) - flush_start < flush_timeout:
             await asyncio.sleep(flush_sleep_interval)  # wait a bit
             # check to see if the items in our flush set are still there
             remaining_set = set()
@@ -322,7 +322,7 @@ async def POST_Root(request):
             log.error("unexpected value for timestamp: {params}")
             raise HTTPInternalServerError()
     else:
-        timestamp = time.time()
+        timestamp = getNow(app)
 
     log.info(f"POST_Root: {root_id} bucket: {bucket} timestamp: {timestamp}")
 

--- a/hsds/link_dn.py
+++ b/hsds/link_dn.py
@@ -13,7 +13,6 @@
 # data node of hsds cluster
 #
 
-import time
 from copy import copy
 from bisect import bisect_left
 
@@ -25,6 +24,7 @@ from .util.idUtil import isValidUuid
 from .util.globparser import globmatch
 from .util.linkUtil import validateLinkName, getLinkClass, isEqualLink
 from .util.domainUtil import isValidBucketName
+from .util.timeUtil import getNow
 from .datanode_lib import get_obj_id, get_metadata_obj, save_metadata_obj
 from . import hsds_logger as log
 
@@ -365,7 +365,8 @@ async def PUT_Links(request):
     else:
         link_delete_set = set()
 
-    create_time = time.time()
+    create_time = getNow(app)
+
     for title in new_links:
         item = items[title]
         item["created"] = create_time
@@ -472,7 +473,7 @@ async def DELETE_Links(request):
 
     if save_obj:
         # update the group lastModified
-        now = time.time()
+        now = getNow(app)
         group_json["lastModified"] = now
 
         # write back to S3

--- a/hsds/util/timeUtil.py
+++ b/hsds/util/timeUtil.py
@@ -58,3 +58,13 @@ def elapsedTime(timestamp):
         ret_str += "{} minutes ".format(minutes)
     ret_str += "{} seconds".format(delta)
     return ret_str
+
+
+def getNow(app):
+    """
+    Get current time in unix timestamp
+
+    Returns a precise timestamp even on platforms where
+    time.time() has low resolution (e.g. Windows)
+    """
+    return (time.perf_counter() - app["start_time_relative"]) + app["start_time"]


### PR DESCRIPTION
On Windows, `time.time()` has a low resolution (~16ms), so objects created in sequence sometimes have the same 'created' timestamp.

Creation time is now computed by adding the precise time elapsed since node startup (from `time.perf_counter`) to the recorded unix time at node startup, in the new helper `timeUtil.getNow()`.

Fixes #344