### PR TITLE
remover docker compose version

### DIFF
--- a/admin/docker/docker-compose-internal-lb.yml
+++ b/admin/docker/docker-compose-internal-lb.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   head:
     image: hdfgroup/hsds

--- a/admin/docker/docker-compose.aws.yml
+++ b/admin/docker/docker-compose.aws.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   head:
     image: hdfgroup/hsds

--- a/admin/docker/docker-compose.azure.yml
+++ b/admin/docker/docker-compose.azure.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   head:
     image: hdfgroup/hsds

--- a/admin/docker/docker-compose.posix.yml
+++ b/admin/docker/docker-compose.posix.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   head:
     image: hdfgroup/hsds

--- a/admin/docker/docker-compose.yml
+++ b/admin/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   head:
     image: hdfgroup/hsds


### PR DESCRIPTION
Remove version key work in docker compose to avoid deprecation warning.  See: https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-top-level-element.