### PR TITLE
remove dns style for domains

### DIFF
--- a/hsds/domain_sn.py
+++ b/hsds/domain_sn.py
@@ -163,7 +163,7 @@ async def get_domains(request):
     # allow domain with / to indicate a folder
     prefix = None
     try:
-        prefix = getDomainFromRequest(request, validate=False, allow_dns=False)
+        prefix = getDomainFromRequest(request, validate=False)
     except ValueError:
         pass  # igore
     if not prefix:

--- a/hsds/util/domainUtil.py
+++ b/hsds/util/domainUtil.py
@@ -228,7 +228,6 @@ def validateDomain(id):
         raise ValueError("Slash at end not allowed")
     # the non-bucket part of the domain should start with '/'
     domain_path = getPathForDomain(id)
-    print("domain_path:", domain_path)
     if not domain_path or domain_path[0] != "/":
         raise ValueError("Domain path should start with '/'")
 

--- a/hsds/util/domainUtil.py
+++ b/hsds/util/domainUtil.py
@@ -226,6 +226,11 @@ def validateDomain(id):
         raise ValueError("Domain names should include a '/'")
     if id[-1] == "/":
         raise ValueError("Slash at end not allowed")
+    # the non-bucket part of the domain should start with '/'
+    domain_path = getPathForDomain(id)
+    print("domain_path:", domain_path)
+    if not domain_path or domain_path[0] != "/":
+        raise ValueError("Domain path should start with '/'")
 
 
 def isValidDomain(id):
@@ -263,38 +268,7 @@ def validateDomainKey(domain_key):
         raise ValueError("Invalid domain key")
 
 
-def getDomainForHost(host_value):
-    # Convert domain paths to S3 keys
-    npos = host_value.rfind(":")
-    if npos > 0:
-        host = host_value[:npos]
-    else:
-        host = host_value
-
-    if len(host) < 3:
-        # by equivalence to internet top-level domains, .org, .com, etc
-        raise ValueError("domain name is not valid")
-
-    if host[0] == "." or host[-1] == ".":
-        # can't have a first or last dot'
-        raise ValueError("domain name is not valid")
-
-    dns_path = host.split(".")
-    dns_path.reverse()  # flip to filesystem ordering
-    domain = "/"
-    for field in dns_path:
-        if len(field) == 0:
-            # consecutive dots are not allowed
-            raise ValueError("domain name is not valid")
-        domain += field
-        domain += "/"
-
-    domain = domain[:-1]  # remove trailing slash
-
-    return domain
-
-
-def getDomainFromRequest(request, validate=True, allow_dns=True):
+def getDomainFromRequest(request, validate=True):
     # print("gotDomainFromRequest:", request, "validate=", validate)
     app = request.app
     domain = None
@@ -302,34 +276,16 @@ def getDomainFromRequest(request, validate=True, allow_dns=True):
     params = request.rel_url.query
     if "domain" in params:
         domain = params["domain"]
+    elif "X-Hdf-domain" in request.headers:
+        domain = request.headers["X-Hdf-domain"]
     else:
-        if "host" in params and allow_dns:
-            domain = params["host"]
-        elif "X-Hdf-domain" in request.headers:
-            domain = request.headers["X-Hdf-domain"]
-        elif "X-Forwarded-Host" in request.headers and allow_dns:
-            domain = request.headers["X-Forwarded-Host"]
-        elif allow_dns:
-            domain = request.host
-    if not domain:
-        raise ValueError("no domain")
+        return None
 
     if domain.startswith("hdf5:/"):
         # strip off the prefix to make following logic easier
         domain = domain[6:]
 
-    if domain[0] != "/":
-        # DNS style hostname
-        if validate:
-            validateHostDomain(domain)  # throw ValueError if invalid
-            domain = getDomainForHost(domain)  # convert to s3 path
-        else:
-            try:
-                validateHostDomain(domain)
-                domain = getDomainForHost(domain)
-            except ValueError:
-                pass  # ignore
-    # now validate that its a properly formed domain
+    # validate that its a properly formed domain
     if validate:
         validateDomain(domain)
     if "bucket" in params and params["bucket"]:

--- a/tests/integ/helper.py
+++ b/tests/integ/helper.py
@@ -132,19 +132,6 @@ def getParentDomain(domain):
     return parent
 
 
-def getDNSDomain(domain):
-    """Get DNS-style domain name given a filepath domain"""
-    names = domain.split('/')
-    names.reverse()
-    dns_domain = ''
-    for name in names:
-        if name:
-            dns_domain += name
-            dns_domain += '.'
-    dns_domain = dns_domain[:-1]  # str trailing dot
-    return dns_domain
-
-
 def setupDomain(domain, folder=False, username=None, password=None, root_gcpl=None):
     """Create domain (and parent domain if needed)"""
     endpoint = config.get("hsds_endpoint")

--- a/tests/unit/domain_util_test.py
+++ b/tests/unit/domain_util_test.py
@@ -57,7 +57,6 @@ class DomainUtilTest(unittest.TestCase):
 
         valid_domains = ("/gov/nasa/nex", "/home", s3_path, file_path, azure_path)
         for domain in valid_domains:
-            print(domain)
             self.assertTrue(isValidDomain(domain))
 
     def testValidDomainPath(self):

--- a/tests/unit/domain_util_test.py
+++ b/tests/unit/domain_util_test.py
@@ -15,7 +15,6 @@ import sys
 sys.path.append("../..")
 from hsds.util.domainUtil import getParentDomain, isValidDomain, isValidHostDomain
 from hsds.util.domainUtil import (
-    getDomainForHost,
     isValidDomainPath,
     getBucketForDomain,
     getPathForDomain,
@@ -58,6 +57,7 @@ class DomainUtilTest(unittest.TestCase):
 
         valid_domains = ("/gov/nasa/nex", "/home", s3_path, file_path, azure_path)
         for domain in valid_domains:
+            print(domain)
             self.assertTrue(isValidDomain(domain))
 
     def testValidDomainPath(self):
@@ -67,12 +67,6 @@ class DomainUtilTest(unittest.TestCase):
         valid_domains = ("/home/test_user1/mytests/", "/")
         for domain in valid_domains:
             self.assertTrue(isValidDomainPath(domain))
-
-    def testGetDomainForHost(self):
-        domain = getDomainForHost("nex.nasa.gov")
-        self.assertEqual(domain, "/gov/nasa/nex")
-        domain = getDomainForHost("my-data.nex.nasa.gov")
-        self.assertEqual(domain, "/gov/nasa/nex/my-data")
 
     def testGetParentDomain(self):
 


### PR DESCRIPTION
Removing support for dns-style domain names.
Previously a domain path like: "/home/test_user1/tall.h5" could be expressed as:
"tall.test_user1.home".
The DNS style derived from the original rest HDF white paper: https://www.hdfgroup.org/pubs/papers/RESTful_HDF5.pdf,
but this doesn't seem to have been used in practice or have any special utility over the more common style.  Also, there's some ambiguity with dots that are used as part of the filename rather than a folder separator. 