### PR TITLE
Fix 409 Conflict in domain test on Windows

### DIFF
--- a/tests/integ/domain_test.py
+++ b/tests/integ/domain_test.py
@@ -521,7 +521,7 @@ class DomainTest(unittest.TestCase):
             self.assertEqual(root_id, rspJson["root"])
 
     def testCreateDomainNodeIds(self):
-        domain = self.base_domain + "/newdomain.h6"
+        domain = self.base_domain + "/newdomain.h7"
         print("testCreateDomainNodeIds", domain)
         headers = helper.getRequestHeaders(domain=domain)
         req = helper.getEndpoint() + "/"


### PR DESCRIPTION
`testCreateDomainNodeIds` sometimes gets an HTTPConflict trying to create its domain. This is because the domain helpers generate a domain name based on the current timestamp and the given domain name. Both this test and `testCreateDomain` use the same given domain name of `newdomain.h6`, and because of Windows' low time resolution, sometimes both domains are created at the same timestamp and have a name conflict. 

This PR changes the name of the domain in `testCreateDomainNodeIds` to avoid the conflict regardless of timestamp.

Resolves #353