### PR TITLE
Fix scan timeout on Windows

### DIFF
--- a/hsds/async_lib.py
+++ b/hsds/async_lib.py
@@ -22,11 +22,11 @@ from .util.hdf5dtype import getItemSize, createDataType
 from .util.arrayUtil import getNumElements, bytesToArray
 from .util.dsetUtil import getHyperslabSelection, getFilterOps, getChunkDims, getFilters
 from .util.dsetUtil import getDatasetLayoutClass, getDatasetLayout, getShapeDims
-from .util.timeUtil import getNow
 from .util.storUtil import getStorKeys, putStorJSONObj, getStorJSONObj
 from .util.storUtil import deleteStorObj, getStorBytes, isStorObj
 from . import hsds_logger as log
 from . import config
+import time
 
 # List all keys under given root and optionally update info.json
 # Note: only works with schema v2 domains!
@@ -382,7 +382,7 @@ async def scanRoot(app, rootid, update=False, bucket=None):
     results["logical_bytes"] = 0
     results["checksums"] = {}  # map of objid to checksums
     results["bucket"] = bucket
-    results["scan_start"] = getNow(app)
+    results["scan_start"] = time.time()
 
     app["scanRoot_results"] = results
     app["scanRoot_keyset"] = set()
@@ -437,7 +437,7 @@ async def scanRoot(app, rootid, update=False, bucket=None):
     # free up memory used by the checksums
     del results["checksums"]
 
-    results["scan_complete"] = getNow(app)
+    results["scan_complete"] = time.time()
 
     if update:
         # write .info object back to S3

--- a/tests/integ/value_test.py
+++ b/tests/integ/value_test.py
@@ -14,6 +14,7 @@ import json
 import numpy as np
 import helper
 import config
+import time
 
 
 class ValueTest(unittest.TestCase):
@@ -47,6 +48,7 @@ class ValueTest(unittest.TestCase):
             rsp = self.session.put(req, params=params, headers=headers)
             if (rsp.status_code == 503):
                 # Retry
+                time.sleep(3)
                 continue
             # should get a NO_CONTENT code
             self.assertEqual(rsp.status_code, 204)


### PR DESCRIPTION
After #349, Windows still sometimes has a scan timeout due to `getNow` inaccuracy between nodes. This reverts the scan timestamps to use `time.time()`. Because the [scan check](https://github.com/HDFGroup/hsds/blob/master/hsds/domain_sn.py#L916) now accepts an equal timestamp as satisfying the scan request, the inaccuracy of `time.time()` shouldn't be a problem in this case.