### PR TITLE
Fix some incorrect pattern parsing

### DIFF
--- a/hsds/util/globparser.py
+++ b/hsds/util/globparser.py
@@ -116,7 +116,7 @@ def globmatch(item, pattern):
     asterix_index += 1
     glob_right = pattern[asterix_index:]
     index = _wildcharmatch(item, glob_left)
-    if glob_left and index == 0:
+    if glob_left and index < len(glob_left):
         return False
     item = item[index:]
     if not glob_right:

--- a/tests/unit/glob_parser_test.py
+++ b/tests/unit/glob_parser_test.py
@@ -24,6 +24,7 @@ class GlobParserTest(unittest.TestCase):
     def testPatterns(self):
 
         self.assertTrue(globmatch("ab123", "ab*"))
+        self.assertFalse(globmatch("ab123", "abc*"))
         self.assertTrue(globmatch("abc123", "*123"))
         self.assertTrue(globmatch("abcxyz", "abc*xyz"))
         self.assertTrue(globmatch("abc123xyz", "abc*xyz"))


### PR DESCRIPTION
Pattern with asterisks at the end are incorrectly considered matches, even if the preceding pattern does not match