### PR TITLE
Use old requests version

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,3 +18,6 @@ jobs:
         uses: actions/checkout@v3
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v1
+        with:
+          # verify=False is never used in HSDS
+          allow-ghsas: ["GHSA-9wx4-h78v-vm56"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "pyjwt",
     "pytz",
     "pyyaml",
+    "requests <= 2.31.0",
     "requests-unixsocket",
     "simplejson",
     "s3fs",

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ psutil
 pyjwt
 pytz
 pyyaml
+requests<=2.31.0
 requests-unixsocket
 simplejson
 s3fs


### PR DESCRIPTION
The requests 2.32.0 update from a couple days ago breaks requests-unixsocket for connections to a local socket. There is [a PR](https://github.com/msabramo/requests-unixsocket/pull/72) to requests-unixsocket, but until that gets in we should constrain the requests version