### PR TITLE
Return 404 for S3 PermanentRedirect exceptions

### DIFF
--- a/hsds/util/s3Client.py
+++ b/hsds/util/s3Client.py
@@ -374,7 +374,7 @@ class S3Client:
                 }
             except ClientError as ce:
                 response_code = ce.response["Error"]["Code"]
-                if response_code == "NoSuchBucket":
+                if response_code in ("NoSuchBucket", "PermanentRedirect"):
                     msg = f"s3_bucket: {bucket} not found"
                     log.warn(msg)
                     raise HTTPNotFound()

--- a/hsds/util/s3Client.py
+++ b/hsds/util/s3Client.py
@@ -314,7 +314,7 @@ class S3Client:
                     msg = f"s3_key: {bucket}/{key} not found "
                     log.info(msg)
                     raise HTTPNotFound()
-                elif response_code == "NoSuchBucket":
+                elif response_code in ("NoSuchBucket", "PermanentRedirect"):
                     msg = f"s3_bucket: {bucket} not found"
                     log.info(msg)
                     raise HTTPNotFound()


### PR DESCRIPTION
S3 was raising PermanentRedirect error when a bucket did not exist.  Catching this and returning 404 for put or get object.