### PR TITLE
Prevent use of new major numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "cryptography",
     "h5py >= 3.6.0",
     "numcodecs",
-    "numpy",
+    "numpy < 2.0.0",
     "psutil",
     "pyjwt",
     "pytz",

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ bitshuffle
 cryptography
 h5py>=3.6.0
 numcodecs
-numpy
+numpy<2.0.0
 psutil
 pyjwt
 pytz


### PR DESCRIPTION
Numpy just had its [first major release in years](https://github.com/numpy/numpy/releases/tag/v2.0.0), with breaking changes to its API. We should eventually  add compatibility, but for now just restrict the numpy dependency to a pre-2.0.0 version.