### PR TITLE
Set platform in docker-compose so it works on other platforms than amd64

### DIFF
--- a/admin/docker/docker-compose-internal-lb.yml
+++ b/admin/docker/docker-compose-internal-lb.yml
@@ -1,5 +1,6 @@
 services:
   head:
+    platform: "linux/amd64"
     image: hdfgroup/hsds
     restart: ${RESTART_POLICY}
     mem_limit: ${HEAD_RAM}
@@ -18,6 +19,7 @@ services:
     volumes:
       - ${PWD}/admin/config/:/config/
   dn:
+    platform: "linux/amd64"
     image: hdfgroup/hsds
     restart: ${RESTART_POLICY}
     mem_limit: ${DN_RAM}
@@ -37,6 +39,7 @@ services:
     volumes:
       - ${PWD}/admin/config/:/config/
   sn:
+    platform: "linux/amd64"
     image: hdfgroup/hsds
     restart: ${RESTART_POLICY}
     mem_limit: ${SN_RAM}

--- a/admin/docker/docker-compose.aws.yml
+++ b/admin/docker/docker-compose.aws.yml
@@ -1,5 +1,6 @@
 services:
   head:
+    platform: "linux/amd64"
     image: hdfgroup/hsds
     restart: ${RESTART_POLICY}
     mem_limit: ${HEAD_RAM}
@@ -19,6 +20,7 @@ services:
       - ${PWD}/admin/config/:/config/
 
   dn:
+    platform: "linux/amd64"
     image: hdfgroup/hsds
     restart: ${RESTART_POLICY}
     mem_limit: ${DN_RAM}
@@ -40,6 +42,7 @@ services:
       - head
 
   sn:
+    platform: "linux/amd64"
     image: hdfgroup/hsds
     restart: ${RESTART_POLICY}
     mem_limit: ${SN_RAM}

--- a/admin/docker/docker-compose.azure.yml
+++ b/admin/docker/docker-compose.azure.yml
@@ -1,5 +1,6 @@
 services:
   head:
+    platform: "linux/amd64"
     image: hdfgroup/hsds
     restart: ${RESTART_POLICY}
     mem_limit: ${HEAD_RAM}
@@ -16,6 +17,7 @@ services:
       - ${PWD}/admin/config/:/config/
 
   dn:
+    platform: "linux/amd64"
     image: hdfgroup/hsds
     restart: ${RESTART_POLICY}
     mem_limit: ${DN_RAM}
@@ -34,6 +36,7 @@ services:
       - head
 
   sn:
+    platform: "linux/amd64"
     image: hdfgroup/hsds
     restart: ${RESTART_POLICY}
     mem_limit: ${SN_RAM}

--- a/admin/docker/docker-compose.posix.yml
+++ b/admin/docker/docker-compose.posix.yml
@@ -1,5 +1,6 @@
 services:
   head:
+    platform: "linux/amd64"
     image: hdfgroup/hsds
     restart: ${RESTART_POLICY}
     mem_limit: ${HEAD_RAM}
@@ -16,6 +17,7 @@ services:
       - ${PWD}/admin/config/:/config/
 
   dn:
+    platform: "linux/amd64"
     image: hdfgroup/hsds
     restart: ${RESTART_POLICY}
     mem_limit: ${DN_RAM}
@@ -33,6 +35,7 @@ services:
     links:
       - head
   sn:
+    platform: "linux/amd64"
     image: hdfgroup/hsds
     restart: ${RESTART_POLICY}
     mem_limit: ${SN_RAM}

--- a/admin/docker/docker-compose.yml
+++ b/admin/docker/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   head:
+    platform: "linux/amd64"
     image: hdfgroup/hsds
     restart: ${RESTART_POLICY}
     mem_limit: ${HEAD_RAM}
@@ -19,6 +20,7 @@ services:
       - ${PWD}/admin/config/:/config/
 
   dn:
+    platform: "linux/amd64"
     image: hdfgroup/hsds
     restart: ${RESTART_POLICY}
     mem_limit: ${DN_RAM}
@@ -40,6 +42,7 @@ services:
       - head
 
   sn:
+    platform: "linux/amd64"
     image: hdfgroup/hsds
     restart: ${RESTART_POLICY}
     mem_limit: ${SN_RAM}


### PR DESCRIPTION
With this change, runall.sh works on e.g. macos with Apple Silicon.