### PR TITLE
extend fix

### DIFF
--- a/hsds/dset_dn.py
+++ b/hsds/dset_dn.py
@@ -281,8 +281,6 @@ async def PUT_DatasetShape(request):
                 selection += f"{lb}:{ub}"
                 dims[i] = ub
             else:
-                if dims[i] == 0:
-                    dims[i] = 1  # each dimension must be non-zero
                 selection += ":"
             if i < len(dims) - 1:
                 selection += ","


### PR DESCRIPTION
Don't change zero extents to one on a PUT datashape requests.