### PR TITLE
Fix CI failures due to domain name conflits

### DIFF
--- a/tests/integ/helper.py
+++ b/tests/integ/helper.py
@@ -13,14 +13,9 @@ import requests
 import requests_unixsocket
 import json
 import os.path as op
-from datetime import datetime
-import time
+import random
+import string
 import base64
-try:
-    import pytz
-    USE_UTC = True
-except ModuleNotFoundError:
-    USE_UTC = False
 
 import config
 
@@ -74,11 +69,6 @@ def getActiveNodeCount(session=None):
 
 def getTestDomainName(name):
     """Get base domain to use for test_cases"""
-    now = time.time()
-    if USE_UTC:
-        dt = datetime.fromtimestamp(now, pytz.utc)
-    else:
-        dt = datetime.fromtimestamp(now)
     domain = "/home/"
     domain += config.get('user_name')
     domain += '/'
@@ -86,8 +76,8 @@ def getTestDomainName(name):
     domain += '/'
     domain += name.lower()
     domain += '/'
-    domain += "{:04d}{:02d}{:02d}T{:02d}{:02d}{:02d}_{:06d}Z".format(
-        dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.microsecond)
+    random_str = ''.join(random.choices(string.ascii_lowercase + string.digits, k=8))
+    domain += random_str
     return domain
 
 

--- a/tests/perf/stream/helper.py
+++ b/tests/perf/stream/helper.py
@@ -13,14 +13,9 @@ import requests
 import requests_unixsocket
 import json
 import os.path as op
-from datetime import datetime
-import time
+import random
+import string
 import base64
-try:
-    import pytz
-    USE_UTC = True
-except ModuleNotFoundError:
-    USE_UTC = False
 
 import config
 
@@ -74,11 +69,6 @@ def getActiveNodeCount(session=None):
 
 def getTestDomainName(name):
     """Get base domain to use for test_cases"""
-    now = time.time()
-    if USE_UTC:
-        dt = datetime.fromtimestamp(now, pytz.utc)
-    else:
-        dt = datetime.fromtimestamp(now)
     domain = "/home/"
     domain += config.get('user_name')
     domain += '/'
@@ -86,8 +76,8 @@ def getTestDomainName(name):
     domain += '/'
     domain += name.lower()
     domain += '/'
-    domain += "{:04d}{:02d}{:02d}T{:02d}{:02d}{:02d}_{:06d}Z".format(
-        dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.microsecond)
+    random_str = ''.join(random.choices(string.ascii_lowercase + string.digits, k=8))
+    domain += random_str
     return domain
 
 


### PR DESCRIPTION
- Prevent domain name conflict during tests

Tests use the timestamp to generate unique domain names and avoid conflicts. On windows, the timestamp resolution is low enough that these sometimes have the same timestamp and still conflict with a 409 error.

This replaces the timestamp with an 8-character random string, which should have less than a one in a million chance of a name conflict.

We should probably remove the duplicated test helpers at some point, but it seems like setting up a shared import between the tests that would use it is non-trivial
