### PR TITLE
Add Ubuntu 22.04 back into CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-22.04, ubuntu-latest, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         build-method: ["manual", "docker"]
 


### PR DESCRIPTION
ubuntu-latest now refers to Ubuntu 24.04 instead of 22.04.