### PR TITLE
Fix CreateOrder option in group/link tests

### DIFF
--- a/tests/integ/group_test.py
+++ b/tests/integ/group_test.py
@@ -435,7 +435,7 @@ class GroupTest(unittest.TestCase):
         req = endpoint + "/groups"
 
         # create a new group
-        creation_props = {"link_creation_order": True, "rdcc_nbytes": 1024}
+        creation_props = {"CreateOrder": True, "rdcc_nbytes": 1024}
         payload = {"creationProperties": creation_props}
         rsp = self.session.post(req, data=json.dumps(payload), headers=headers)
         self.assertEqual(rsp.status_code, 201)
@@ -457,7 +457,7 @@ class GroupTest(unittest.TestCase):
         self.assertTrue("domain" in rspJson)
         self.assertTrue("creationProperties" in rspJson)
         cprops = rspJson["creationProperties"]
-        for k in ("link_creation_order", "rdcc_nbytes"):
+        for k in ("CreateOrder", "rdcc_nbytes"):
             self.assertTrue(k in cprops)
             self.assertEqual(cprops[k], creation_props[k])
         self.assertEqual(rspJson["domain"], self.base_domain)

--- a/tests/integ/link_test.py
+++ b/tests/integ/link_test.py
@@ -1037,7 +1037,7 @@ class LinkTest(unittest.TestCase):
 
     def testRootH5Path(self):
         # test that root group can be found by h5path
-        creation_props = {"link_creation_order": True, "rdcc_nbytes": 1024}
+        creation_props = {"CreateOrder": True, "rdcc_nbytes": 1024}
         domain = self.base_domain + "/testRootH5Path.h5"
         print("testRootH5Path", domain)
         helper.setupDomain(domain, root_gcpl=creation_props)
@@ -1067,7 +1067,7 @@ class LinkTest(unittest.TestCase):
         self.assertEqual(rspJson["class"], "group")
 
         cprops = rspJson["creationProperties"]
-        for k in ("link_creation_order", "rdcc_nbytes"):
+        for k in ("CreateOrder", "rdcc_nbytes"):
             self.assertTrue(k in cprops)
             self.assertEqual(cprops[k], creation_props[k])
 


### PR DESCRIPTION
`link_creation_order` isn't a supported parameter. The name of the intended option is `CreateOrder`.