### PR TITLE
Prevent resource conflicts in tests

### DIFF
--- a/tests/integ/dataset_test.py
+++ b/tests/integ/dataset_test.py
@@ -546,7 +546,7 @@ class DatasetTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link the new dataset
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -1633,7 +1633,7 @@ class DatasetTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -1686,7 +1686,7 @@ class DatasetTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -1743,7 +1743,7 @@ class DatasetTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -2138,7 +2138,7 @@ class DatasetTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -2216,7 +2216,7 @@ class DatasetTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -2301,7 +2301,7 @@ class DatasetTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -2385,7 +2385,7 @@ class DatasetTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -2481,7 +2481,7 @@ class DatasetTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -2542,7 +2542,7 @@ class DatasetTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -2605,7 +2605,7 @@ class DatasetTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)

--- a/tests/integ/filter_test.py
+++ b/tests/integ/filter_test.py
@@ -74,7 +74,7 @@ class FilterTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -129,7 +129,7 @@ class FilterTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -191,7 +191,7 @@ class FilterTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -246,7 +246,7 @@ class FilterTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -308,7 +308,7 @@ class FilterTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -493,7 +493,7 @@ class FilterTest(unittest.TestCase):
         rspJson = json.loads(rsp.text)
         dset_uuid = rspJson["id"]
         self.assertTrue(helper.validateId(dset_uuid))
-        req = self.endpoint + "/groups/" + root_uuid + "/links/" + "dset"
+        req = self.endpoint + "/groups/" + root_uuid + "/links/" + "dset" + helper.getRandomName()
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
         self.assertEqual(rsp.status_code, 201, rsp.text)

--- a/tests/integ/helper.py
+++ b/tests/integ/helper.py
@@ -81,6 +81,12 @@ def getTestDomainName(name):
     return domain
 
 
+def getRandomName():
+    """Return a random name"""
+    random_str = ''.join(random.choices(string.ascii_lowercase + string.digits, k=8))
+    return random_str
+
+
 def getRequestHeaders(domain=None, username=None, bucket=None, password=None, **kwargs):
     """Get default request headers for domain"""
     if username is None:

--- a/tests/integ/pointsel_test.py
+++ b/tests/integ/pointsel_test.py
@@ -93,7 +93,7 @@ class PointSelTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_id))
 
         # link new dataset as 'dset1d'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_id}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -287,7 +287,7 @@ class PointSelTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_id))
 
         # link new dataset as 'dset1d'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_id}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -685,7 +685,7 @@ class PointSelTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_id))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_id}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -836,7 +836,7 @@ class PointSelTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_id))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_id}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -895,7 +895,7 @@ class PointSelTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_id))
 
         # link new dataset as 'dset1d'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_id}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -1062,7 +1062,7 @@ class PointSelTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_id))
 
         # link new dataset as 'dset1d'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_id}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -1171,7 +1171,7 @@ class PointSelTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_id))
 
         # link new dataset as 'dset1d'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_id}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -1729,7 +1729,7 @@ class PointSelTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_id))
 
         # link new dataset as 'dset_compound'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_id}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)

--- a/tests/integ/query_test.py
+++ b/tests/integ/query_test.py
@@ -80,7 +80,7 @@ class QueryTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset1'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -388,7 +388,7 @@ class QueryTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_id))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_id}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -459,7 +459,7 @@ class QueryTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset1'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)

--- a/tests/integ/value_test.py
+++ b/tests/integ/value_test.py
@@ -98,7 +98,7 @@ class ValueTest(unittest.TestCase):
         self.assertEqual(rsp.status_code, 201)  # created
 
         # link new dataset as 'dset1d'
-        name = "dset1d"
+        name = "dset1d" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_id}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -197,7 +197,7 @@ class ValueTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_id))
 
         # link new dataset as 'dset1d'
-        name = "dset1d"
+        name = "dset1d" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_id}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -310,7 +310,7 @@ class ValueTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_id))
 
         # link new dataset as 'dset1d'
-        name = "dset2d"
+        name = "dset2d" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_id}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -421,7 +421,7 @@ class ValueTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_id))
 
         # link new dataset as 'dset2d'
-        name = "dset2d"
+        name = "dset2d" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_id}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -526,7 +526,7 @@ class ValueTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_id))
 
         # link new dataset as 'dset1d'
-        name = "dset1d"
+        name = "dset1d" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_id}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -608,7 +608,7 @@ class ValueTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_id))
 
         # link new dataset as 'dset2d'
-        name = "dset2d"
+        name = "dset2d" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_id}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -1070,7 +1070,7 @@ class ValueTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset1d_uuid))
 
         # link new dataset as 'dset1'
-        name = "dset1d"
+        name = "dset1d" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset1d_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -1164,7 +1164,7 @@ class ValueTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset2d_uuid))
 
         # link new dataset as 'dset2d'
-        name = "dset2d"
+        name = "dset2d" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset2d_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -1238,7 +1238,7 @@ class ValueTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -1392,7 +1392,7 @@ class ValueTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -1453,7 +1453,7 @@ class ValueTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -1535,7 +1535,7 @@ class ValueTest(unittest.TestCase):
         helper.validateId(root_uuid)
 
         # create new group
-        payload = {"link": {"id": root_uuid, "name": "g1"}}
+        payload = {"link": {"id": root_uuid, "name": "g1" + helper.getRandomName()}}
         req = helper.getEndpoint() + "/groups"
         rsp = self.session.post(req, data=json.dumps(payload), headers=headers)
         self.assertEqual(rsp.status_code, 201)
@@ -1604,7 +1604,7 @@ class ValueTest(unittest.TestCase):
         helper.validateId(root_uuid)
 
         # create new group
-        payload = {"link": {"id": root_uuid, "name": "g1"}}
+        payload = {"link": {"id": root_uuid, "name": "g1" + helper.getRandomName()}}
         req = helper.getEndpoint() + "/groups"
         rsp = self.session.post(req, data=json.dumps(payload), headers=headers)
         self.assertEqual(rsp.status_code, 201)
@@ -1886,7 +1886,7 @@ class ValueTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -1974,7 +1974,7 @@ class ValueTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -2070,7 +2070,7 @@ class ValueTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -2168,7 +2168,7 @@ class ValueTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -2487,7 +2487,7 @@ class ValueTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_id))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_id}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -2650,7 +2650,7 @@ class ValueTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_id))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_id}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -2832,7 +2832,7 @@ class ValueTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_id))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_id}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -2968,7 +2968,7 @@ class ValueTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_id))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_id}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -3150,7 +3150,7 @@ class ValueTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_id))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_id}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -3263,7 +3263,7 @@ class ValueTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_id))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_id}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -3381,7 +3381,7 @@ class ValueTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_id))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_id}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -3493,7 +3493,7 @@ class ValueTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_id))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_id}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -3550,7 +3550,7 @@ class ValueTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -3605,7 +3605,7 @@ class ValueTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = f"{self.endpoint}/groups/{root_uuid}/links/{name}"
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -3683,7 +3683,7 @@ class ValueTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = f"{self.endpoint}/groups/{root_uuid}/links/{name}"
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -3802,7 +3802,7 @@ class ValueTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = f"{self.endpoint}/groups/{root_uuid}/links/{name}"
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)

--- a/tests/integ/vlen_test.py
+++ b/tests/integ/vlen_test.py
@@ -68,7 +68,7 @@ class VlenTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -167,7 +167,7 @@ class VlenTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -249,7 +249,7 @@ class VlenTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -329,7 +329,7 @@ class VlenTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -407,7 +407,7 @@ class VlenTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -516,7 +516,7 @@ class VlenTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -623,7 +623,7 @@ class VlenTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)
@@ -751,7 +751,7 @@ class VlenTest(unittest.TestCase):
         self.assertTrue(helper.validateId(dset_uuid))
 
         # link new dataset as 'dset'
-        name = "dset"
+        name = "dset" + helper.getRandomName()
         req = self.endpoint + "/groups/" + root_uuid + "/links/" + name
         payload = {"id": dset_uuid}
         rsp = self.session.put(req, data=json.dumps(payload), headers=headers)

--- a/tests/perf/stream/helper.py
+++ b/tests/perf/stream/helper.py
@@ -81,6 +81,12 @@ def getTestDomainName(name):
     return domain
 
 
+def getRandomName():
+    """Return a random name"""
+    random_str = ''.join(random.choices(string.ascii_lowercase + string.digits, k=8))
+    return random_str
+
+
 def getRequestHeaders(domain=None, username=None, bucket=None, password=None, **kwargs):
     """Get default request headers for domain"""
     if username is None:


### PR DESCRIPTION
Resources conflicts due to resources sharing names in the same domain sometimes cause failures in CI ([example](https://github.com/mattjala/hsds/actions/runs/12468559688/job/34799969915)).

This randomizes names of test dsets/links to prevent conflicts. 