### PR TITLE
Replace deprecated numpy fromstring()

### DIFF
--- a/hsds/attr_sn.py
+++ b/hsds/attr_sn.py
@@ -1088,7 +1088,7 @@ async def PUT_AttributeValue(request):
             msg += f"but got {len(binary_data)}"
             log.warn(msg)
             raise HTTPBadRequest(reason=msg)
-        arr = np.fromstring(binary_data, dtype=np_dtype)
+        arr = np.frombuffer(binary_data, dtype=np_dtype)
         if attr_shape["class"] == "H5S_SCALAR":
             arr = arr.reshape([])
         else:

--- a/hsds/chunk_sn.py
+++ b/hsds/chunk_sn.py
@@ -853,7 +853,7 @@ async def PUT_Value(request):
                 log.warn(msg)
                 raise HTTPBadRequest(reason=msg)
 
-            arr = np.fromstring(input_data, dtype=dset_dtype)
+            arr = np.frombuffer(input_data, dtype=dset_dtype)
             log.debug(f"read fixed type array: {arr}")
 
         if bc_shape:
@@ -1351,7 +1351,7 @@ async def POST_Value(request):
             log.warn(msg)
             raise HTTPBadRequest(reason=msg)
         num_points = request.content_length // point_dt.itemsize
-        points = np.fromstring(binary_data, dtype=point_dt)
+        points = np.frombuffer(binary_data, dtype=point_dt)
         # reshape the data based on the rank (num_points x rank)
         if rank > 1:
             if len(points) % rank != 0:


### PR DESCRIPTION
Numpy 2.3.0 deprecated the default (binary) mode of `np.fromstring()`. This replaces use of `np.fromstring()` with `np.frombuffer()`, which should have no change in behavior. 