### PR TITLE
Replace unix socket package

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -213,11 +213,6 @@ jobs:
         run: |
           pip install -e .
 
-      # Requests 2.32.0 breaks requests-unixsocket, used by HSDS for socket connections
-      # - name: Fix requests version
-      #  run: |
-      #    pip install requests==2.31.0
-
       - name: Run HSDS unit tests
         shell: bash
         run: |

--- a/Pipfile
+++ b/Pipfile
@@ -19,9 +19,11 @@ psutil = "*"
 pyjwt = "*"
 pytz = "*"
 pyyaml = "*"
-requests-unixsocket = "*"
+requests = "<=2.32.4"
+requests-unixsocket2 = {git = "https://gitlab.com/thelabnyc/requests-unixsocket2.git"}
 simplejson = "*"
 s3fs = "*"
+urllib3 = ">=2.4.0,<3.0"
 
 [dev-packages]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,11 +49,11 @@ dependencies = [
     "pyjwt",
     "pytz",
     "pyyaml",
-    "requests <= 2.31.0",
-    "requests-unixsocket",
+    "requests <= 2.32.4",
+    "requests-unixsocket2 @ git+https://gitlab.com/thelabnyc/requests-unixsocket2.git",
     "simplejson",
     "s3fs",
-    "urllib3 < 2.0.0"
+    "urllib3 >= 2.4.0, < 3.0"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,8 @@ psutil
 pyjwt
 pytz
 pyyaml
-requests<=2.31.0
-requests-unixsocket
+requests<=2.32.4
+requests-unixsocket2 @ git+https://gitlab.com/thelabnyc/requests-unixsocket2.git
 simplejson
 s3fs
-urllib3<2.0.0
+urllib3>=2.4.0,<3.0


### PR DESCRIPTION
- Replace deprecated unixsocket dependency with a fork that is still maintained

The original package is incompatible with requests 2.32.0+. 