### PR TITLE
Skip DockerHub login on Dependabot PRs

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -38,7 +38,12 @@ jobs:
       -
         name: Login to DockerHub
         uses: docker/login-action@v1
-        if: "! github.event.pull_request.head.repo.fork"
+        # Skip when the run has no access to the DOCKERHUB_* secrets, which would
+        # otherwise fail the login with empty credentials: PRs from forks, and
+        # Dependabot PRs (those resolve secrets against the separate Dependabot
+        # store, not the Actions store). Neither run pushes an image anyway --
+        # see the `push:` condition on the build step below.
+        if: "! github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]'"
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}


### PR DESCRIPTION
The `Docker Image CI` workflow fails on every Dependabot PR with an auth error at the login to DockerHub step.

`docker/login-action` is given `secrets.DOCKERHUB_USERNAME` / `DOCKERHUB_PASSWORD`. When those resolve to empty strings it attempts the job anyway (and fails).

Two kinds of run cannot see those secrets:

* PRs from forks. GitHub withholds secrets from untrusted contributors. This case is already prevented from trying to login by the existing `! github.event.pull_request.head.repo.fork` check.
* Dependabot PRs. GitHub resolves `secrets.*` for Dependabot-triggered runs against a separate Dependabot secret store, not the Actions store.

Because Dependabot branches live in this repo, the existing check lets Dependabot PRs try to login to DockerHub.

This isn't a problem for regular contributors because they either have write access and push a branch here (have secret access & login succeeds) or open a PR from a fork (no secret access & no login attempt).

This PR extends the existing condition to also skip Dependabot.

Fixes #315