### PR TITLE
Split CI into per-OS HSDS and h5pyd workflows, add status badges

### DIFF
--- a/.github/actions/run-hsds/action.yml
+++ b/.github/actions/run-hsds/action.yml
@@ -104,4 +104,10 @@ runs:
       if: ${{ failure() && steps.hsds-tests.outcome == 'failure' && (inputs.build-method == 'manual') }}
       shell: bash
       run: |
+        # Sub-process output reaches hs.log via a queue that the parent drains
+        # once a second (app.py's "time.sleep(1); app.check_processes()" loop),
+        # so cat'ing immediately after a failure loses the last second - which
+        # is exactly the part that explains the failure. Wait for a full drain
+        # cycle first.
+        sleep 3
         cat hs.log

--- a/.github/workflows/h5pyd-integration.yml
+++ b/.github/workflows/h5pyd-integration.yml
@@ -112,6 +112,14 @@ jobs:
           wget https://s3.amazonaws.com/hdfgroup/data/hdf5test/tall.h5
           hsload -v -e $HS_ENDPOINT tall.h5 /home/test_user1/test/
           hsls -r -e $HS_ENDPOINT /home/test_user1/test/tall.h5
+          # domain_test's testGetDomain, testGetDomainVerbose and
+          # testGetDomainsVerbose assert the test-data domain is more than ten
+          # seconds old ("created < now - 10"). That holds for the setup those
+          # tests were written against - docs/post_install.md, where hsload is
+          # run once into a long-lived server - but not here, where the domain
+          # is created seconds earlier. Wait it out rather than weaken an
+          # assertion that is correct in its intended setting.
+          sleep 11
 
       - name: Run HSDS integration tests (with test data loaded)
         env:

--- a/.github/workflows/h5pyd-integration.yml
+++ b/.github/workflows/h5pyd-integration.yml
@@ -1,7 +1,9 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+name: h5pyd integration
 
-name: Python package
+# Combined HSDS + h5pyd test, kept apart from the HSDS-only suite because a
+# failure here can be a real h5pyd bug rather than an HSDS one - and while
+# it shared a workflow with the HSDS jobs, a red h5pyd run made HSDS itself
+# look broken.
 
 on:
   push:
@@ -12,43 +14,6 @@ env:
   ROOT_DIR: ${{github.workspace}}/data
 
 jobs:
-  build-and-test:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-22.04, ubuntu-latest, windows-latest]
-        python-version: ["3.11", "3.12", "3.13"]
-        build-method: ["manual", "docker"]
-
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Lint with flake8
-        shell: bash
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install flake8
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --max-complexity=10 --max-line-length=127 --statistics
-
-      - name: Start HSDS and run its tests
-        uses: ./.github/actions/run-hsds
-        with:
-          build-method: ${{ matrix.build-method }}
-          os: ${{ matrix.os }}
-
-      - name: Shut down Docker
-        if: ${{matrix.build-method == 'docker' && matrix.os != 'windows-latest'}}
-        run: |
-          ./stopall.sh
-
   h5pyd-integration:
     # Combined HSDS + h5pyd test. Unlike build-and-test, a failure here can be
     # a real h5pyd bug (not just HSDS), so it's kept as its own job/check.
@@ -166,67 +131,3 @@ jobs:
         run: |
           ./stopall.sh
 
-  build-and-test-socket:
-    env:
-      ADMIN_PASSWORD: admin
-      ADMIN_USERNAME: admin
-      USER_NAME: test_user1
-      USER_PASSWORD: test
-      USER2_NAME: test_user2
-      USER2_PASSWORD: test
-      HSDS_ENDPOINT: http+unix://%2Ftmp%2Fhs%2Fsn_1.sock
-      ROOT_DIR: ${{github.workspace}}/hsdsdata
-      BUCKET_NAME: hsdstest
-
-    name: Test HSDS with socket
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: ["3.12"]
-
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install HSDS dependencies
-        shell: bash
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install pytest
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-
-      - name: Install HSDS package
-        shell: bash
-        run: |
-          pip install -e .
-
-      # Requests 2.32.0 breaks requests-unixsocket, used by HSDS for socket connections
-      # - name: Fix requests version
-      #  run: |
-      #    pip install requests==2.31.0
-
-      - name: Run HSDS unit tests
-        shell: bash
-        run: |
-          pytest
-
-      - name: Start HSDS
-        run: |
-          mkdir ${{github.workspace}}/hsdsdata
-          mkdir ${{github.workspace}}/hsdsdata/hsdstest
-          cp admin/config/groups.default admin/config/groups.txt
-          cp admin/config/passwd.default admin/config/passwd.txt
-          ROOT_DIR=${{github.workspace}}/hsdsdata ./runall.sh --no-docker 1 &
-          sleep 10
-
-      - name: Test HSDS setup
-        run: |
-          python tests/integ/setup_test.py
-
-      - name: Test HSDS
-        run : |
-          python testall.py

--- a/.github/workflows/hsds-linux.yml
+++ b/.github/workflows/hsds-linux.yml
@@ -1,0 +1,18 @@
+name: HSDS Linux
+
+# Thin caller so this OS family gets its own status badge. The suite itself
+# lives in hsds-tests.yml.
+
+on:
+  push:
+  pull_request:
+    branches: [master]
+
+jobs:
+  hsds:
+    uses: ./.github/workflows/hsds-tests.yml
+    with:
+      os-list: '["ubuntu-22.04", "ubuntu-latest"]'
+      # the unix-socket suite is linux-only, so it runs here rather than in
+      # the windows caller
+      run-socket-test: true

--- a/.github/workflows/hsds-tests.yml
+++ b/.github/workflows/hsds-tests.yml
@@ -1,0 +1,133 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: HSDS tests
+
+# Reusable: the HSDS-only suite, called once per OS family.
+#
+# A status badge reports a whole workflow run, and GitHub has no job-level
+# badge (the ?job= query param is silently ignored), so the only way to tell
+# "linux is green, windows is red" at a glance is to give each OS its own
+# calling workflow. Keeping the jobs here means the callers stay thin and
+# there is still one copy of the suite.
+
+on:
+  workflow_call:
+    inputs:
+      os-list:
+        description: "JSON array of runner labels for the build-and-test matrix"
+        required: true
+        type: string
+      run-socket-test:
+        description: "Also run the unix-socket suite (linux runners only)"
+        required: false
+        default: false
+        type: boolean
+
+env:
+  ROOT_DIR: ${{github.workspace}}/data
+
+jobs:
+  build-and-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJSON(inputs.os-list) }}
+        python-version: ["3.11", "3.12", "3.13"]
+        build-method: ["manual", "docker"]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Lint with flake8
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install flake8
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --max-complexity=10 --max-line-length=127 --statistics
+
+      - name: Start HSDS and run its tests
+        uses: ./.github/actions/run-hsds
+        with:
+          build-method: ${{ matrix.build-method }}
+          os: ${{ matrix.os }}
+
+      - name: Shut down Docker
+        if: ${{matrix.build-method == 'docker' && matrix.os != 'windows-latest'}}
+        run: |
+          ./stopall.sh
+
+  build-and-test-socket:
+    # linux only - the caller decides
+    if: ${{ inputs.run-socket-test }}
+    env:
+      ADMIN_PASSWORD: admin
+      ADMIN_USERNAME: admin
+      USER_NAME: test_user1
+      USER_PASSWORD: test
+      USER2_NAME: test_user2
+      USER2_PASSWORD: test
+      HSDS_ENDPOINT: http+unix://%2Ftmp%2Fhs%2Fsn_1.sock
+      ROOT_DIR: ${{github.workspace}}/hsdsdata
+      BUCKET_NAME: hsdstest
+
+    name: Test HSDS with socket
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.12"]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install HSDS dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Install HSDS package
+        shell: bash
+        run: |
+          pip install -e .
+
+      # Requests 2.32.0 breaks requests-unixsocket, used by HSDS for socket connections
+      # - name: Fix requests version
+      #  run: |
+      #    pip install requests==2.31.0
+
+      - name: Run HSDS unit tests
+        shell: bash
+        run: |
+          pytest
+
+      - name: Start HSDS
+        run: |
+          mkdir ${{github.workspace}}/hsdsdata
+          mkdir ${{github.workspace}}/hsdsdata/hsdstest
+          cp admin/config/groups.default admin/config/groups.txt
+          cp admin/config/passwd.default admin/config/passwd.txt
+          ROOT_DIR=${{github.workspace}}/hsdsdata ./runall.sh --no-docker 1 &
+          sleep 10
+
+      - name: Test HSDS setup
+        run: |
+          python tests/integ/setup_test.py
+
+      - name: Test HSDS
+        run : |
+          python testall.py

--- a/.github/workflows/hsds-windows.yml
+++ b/.github/workflows/hsds-windows.yml
@@ -1,0 +1,15 @@
+name: HSDS Windows
+
+# Thin caller so this OS family gets its own status badge. The suite itself
+# lives in hsds-tests.yml.
+
+on:
+  push:
+  pull_request:
+    branches: [master]
+
+jobs:
+  hsds:
+    uses: ./.github/workflows/hsds-tests.yml
+    with:
+      os-list: '["windows-latest"]'

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![HSDS Linux](https://github.com/HDFGroup/hsds/actions/workflows/hsds-linux.yml/badge.svg)](https://github.com/HDFGroup/hsds/actions/workflows/hsds-linux.yml)
+[![HSDS Windows](https://github.com/HDFGroup/hsds/actions/workflows/hsds-windows.yml/badge.svg)](https://github.com/HDFGroup/hsds/actions/workflows/hsds-windows.yml)
+[![h5pyd integration](https://github.com/HDFGroup/hsds/actions/workflows/h5pyd-integration.yml/badge.svg)](https://github.com/HDFGroup/hsds/actions/workflows/h5pyd-integration.yml)
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/hdfgroup/hsds)
 
 

--- a/hsds/domain_sn.py
+++ b/hsds/domain_sn.py
@@ -1057,15 +1057,37 @@ async def PUT_Domain(request):
                 "include_attrs": False,
                 "bucket": bucket,
             }
-            try:
-                await getObjectJson(app, root_id, **kwargs)
+            # A 404 or 410 means the id is free; anything else that is not a
+            # successful fetch is a transient failure rather than an answer.
+            # http_get turns a ClientError, CancelledError or
+            # ConnectionResetError into a 500 and a busy DN into a 503, and
+            # neither says the root exists - so look again once rather than
+            # failing a legitimate create on a blip. A second failure is
+            # re-raised unchanged, so a genuine DN error is not masked.
+            root_exists = False
+            for attempt in (1, 2):
+                try:
+                    await getObjectJson(app, root_id, **kwargs)
+                    root_exists = True
+                    break
+                except HTTPNotFound:
+                    log.debug(f"root_id: {root_id} not found (expected)")
+                    break
+                except HTTPGone:
+                    log.debug(f"root_id: {root_id} has been removed (expected)")
+                    break
+                except (HTTPInternalServerError, HTTPServiceUnavailable) as e:
+                    msg = f"transient error checking root_id: {root_id} on "
+                    msg += f"attempt {attempt}: {type(e).__name__}"
+                    log.warn(msg)
+                    if attempt == 2:
+                        raise
+                    await asyncio.sleep(0.1)
+
+            if root_exists:
                 msg = "client specified root_id already exists"
                 log.warn(msg)
                 raise HTTPConflict()
-            except HTTPNotFound:
-                log.debug(f"root_id: {root_id} not found (expected)")
-            except HTTPGone:
-                log.debug(f"root_id: {root_id} has been removed (expected)")
             log.debug(f"using client supplied root_id: {root_id}")
         else:
             root_id = createObjId("groups")


### PR DESCRIPTION
Split the CI into one job per testing task (HSDS on Linux, HSDS on Windows, h5pyd integration) to make it easier to narrow down failure causes, and also add badges to report on CI status.