### PR TITLE
Remove duplicate test suite execution

### DIFF
--- a/.github/actions/run-hsds/action.yml
+++ b/.github/actions/run-hsds/action.yml
@@ -10,6 +10,14 @@ inputs:
   os:
     description: "matrix.os of the calling job (used to skip docker on windows)"
     required: true
+  run-tests:
+    description: >
+      Run the unit and integration suites after starting HSDS. Callers that
+      only need a running server - test-data-setup, which loads sample data
+      and then runs the suite itself - should pass "false" so the suite is not
+      run twice, once of them against a server with no test data.
+    required: false
+    default: "true"
 runs:
   using: "composite"
   steps:
@@ -26,6 +34,7 @@ runs:
         pip install -e .
 
     - name: Run unit tests
+      if: ${{ inputs.run-tests == 'true' }}
       shell: bash
       run: |
         pytest
@@ -73,7 +82,7 @@ runs:
         sleep 45
 
     - name: Run HSDS tests
-      if: ${{ !(inputs.build-method == 'docker' && inputs.os == 'windows-latest') }}
+      if: ${{ inputs.run-tests == 'true' && !(inputs.build-method == 'docker' && inputs.os == 'windows-latest') }}
       id: hsds-tests
       shell: bash
       env:

--- a/.github/workflows/h5pyd-integration.yml
+++ b/.github/workflows/h5pyd-integration.yml
@@ -90,6 +90,10 @@ jobs:
         with:
           build-method: docker
           os: ubuntu-latest
+          # this job runs the suite itself further down, against the loaded
+          # test data - running it here too would run it twice, and the first
+          # pass would be against a server with no test data
+          run-tests: "false"
 
       - name: Checkout h5pyd
         uses: actions/checkout@v4
@@ -101,6 +105,22 @@ jobs:
         working-directory: ${{github.workspace}}/h5pyd
         run: |
           pip install . -v
+
+      - name: Create home folders
+        # hstouch/hsload below need /home/<user>/ to already exist. That is
+        # created by setup_test, which testall.py runs first - so this job used
+        # to get it as a side effect of the suite run that has now been turned
+        # off. Do it explicitly instead.
+        env:
+          ADMIN_USERNAME: admin
+          ADMIN_PASSWORD: admin
+          USER_NAME: test_user1
+          USER_PASSWORD: test
+          USER2_NAME: test_user2
+          USER2_PASSWORD: test
+          BUCKET_NAME: hsdstest
+        run: |
+          python tests/integ/setup_test.py
 
       - name: Load test data
         env:

--- a/tests/integ/attr_test.py
+++ b/tests/integ/attr_test.py
@@ -2028,9 +2028,7 @@ class AttributeTest(unittest.TestCase):
         req = helper.getEndpoint() + "/"
         rsp = self.session.get(req, headers=headers)
         if rsp.status_code != 200:
-            msg = f"WARNING: Failed to get domain: {domain}. Is test data setup?"
-            print(msg)
-            return  # abort rest of test
+            self.skipTest(f'{domain}: test data not loaded - see docs/post_install.md')
         domainJson = json.loads(rsp.text)
         root_id = domainJson["root"]
         helper.validateId(root_id)
@@ -2105,9 +2103,7 @@ class AttributeTest(unittest.TestCase):
         req = helper.getEndpoint() + "/"
         rsp = self.session.get(req, headers=headers)
         if rsp.status_code != 200:
-            msg = f"WARNING: Failed to get domain: {domain}. Is test data setup?"
-            print(msg)
-            return  # abort rest of test
+            self.skipTest(f'{domain}: test data not loaded - see docs/post_install.md')
         domainJson = json.loads(rsp.text)
         root_id = domainJson["root"]
         helper.validateId(root_id)
@@ -2498,9 +2494,7 @@ class AttributeTest(unittest.TestCase):
         req = helper.getEndpoint() + "/"
         rsp = self.session.get(req, headers=headers)
         if rsp.status_code != 200:
-            msg = f"WARNING: Failed to get domain: {domain}. Is test data setup?"
-            print(msg)
-            return  # abort rest of test
+            self.skipTest(f'{domain}: test data not loaded - see docs/post_install.md')
         domainJson = json.loads(rsp.text)
         root_id = domainJson["root"]
         helper.validateId(root_id)
@@ -2576,8 +2570,7 @@ class AttributeTest(unittest.TestCase):
         req = helper.getEndpoint() + "/"
         rsp = self.session.get(req, headers=headers)
         if rsp.status_code != 200:
-            print(f"WARNING: Failed to get domain: {domain}. Is test data setup?")
-            return  # abort rest of test
+            self.skipTest(f'{domain}: test data not loaded - see docs/post_install.md')
 
         rspJson = json.loads(rsp.text)
         root_uuid = rspJson["root"]
@@ -2626,8 +2619,7 @@ class AttributeTest(unittest.TestCase):
         req = helper.getEndpoint() + "/"
         rsp = self.session.get(req, headers=headers)
         if rsp.status_code != 200:
-            print(f"WARNING: Failed to get domain: {domain}. Is test data setup?")
-            return  # abort rest of test
+            self.skipTest(f'{domain}: test data not loaded - see docs/post_install.md')
 
         rspJson = json.loads(rsp.text)
         root_uuid = rspJson["root"]

--- a/tests/integ/dataset_test.py
+++ b/tests/integ/dataset_test.py
@@ -421,8 +421,7 @@ class DatasetTest(unittest.TestCase):
         req = helper.getEndpoint() + "/"
         rsp = self.session.get(req, headers=headers)
         if rsp.status_code != 200:
-            print(f"WARNING: Failed to get domain: {domain}. Is test data setup?")
-            return  # abort rest of test
+            self.skipTest(f'{domain}: test data not loaded - see docs/post_install.md')
         domainJson = json.loads(rsp.text)
         root_uuid = domainJson["root"]
 
@@ -523,8 +522,7 @@ class DatasetTest(unittest.TestCase):
         req = helper.getEndpoint() + "/"
         rsp = self.session.get(req, headers=headers)
         if rsp.status_code != 200:
-            print(f"WARNING: Failed to get domain: {domain}. Is test data setup?")
-            return  # abort rest of test
+            self.skipTest(f'{domain}: test data not loaded - see docs/post_install.md')
         domainJson = json.loads(rsp.text)
         root_uuid = domainJson["root"]
 
@@ -600,8 +598,7 @@ class DatasetTest(unittest.TestCase):
         req = helper.getEndpoint() + "/"
         rsp = self.session.get(req, headers=headers)
         if rsp.status_code != 200:
-            print(f"WARNING: Failed to get domain: {domain}. Is test data setup?")
-            return  # abort rest of test
+            self.skipTest(f'{domain}: test data not loaded - see docs/post_install.md')
         domainJson = json.loads(rsp.text)
         root_uuid = domainJson["root"]
         self.assertTrue(helper.validateId(root_uuid))

--- a/tests/integ/domain_test.py
+++ b/tests/integ/domain_test.py
@@ -57,9 +57,7 @@ class DomainTest(unittest.TestCase):
         req = helper.getEndpoint() + "/"
         rsp = self.session.get(req, headers=headers)
         if rsp.status_code != 200:
-            msg = f"WARNING: Failed to get domain: {domain}. Is test data setup?"
-            print(msg)
-            return  # abort rest of test
+            self.skipTest(f'{domain}: test data not loaded - see docs/post_install.md')
         self.assertEqual(rsp.headers["content-type"], "application/json; charset=utf-8")
         rspJson = json.loads(rsp.text)
 
@@ -171,9 +169,7 @@ class DomainTest(unittest.TestCase):
         req = helper.getEndpoint() + "/"
         rsp = self.session.get(req, headers=headers)
         if rsp.status_code != 200:
-            msg = f"WARNING: Failed to get domain: {domain}. Is test data setup?"
-            print(msg)
-            return  # abort rest of test
+            self.skipTest(f'{domain}: test data not loaded - see docs/post_install.md')
         domainJson = json.loads(rsp.text)
         self.assertTrue("root" in domainJson)
         root_id = domainJson["root"]
@@ -216,9 +212,7 @@ class DomainTest(unittest.TestCase):
         req = helper.getEndpoint() + "/"
         rsp = self.session.get(req, headers=headers)
         if rsp.status_code != 200:
-            msg = f"WARNING: Failed to get domain: {domain}. Is test data setup?"
-            print(msg)
-            return  # abort rest of test
+            self.skipTest(f'{domain}: test data not loaded - see docs/post_install.md')
         domainJson = json.loads(rsp.text)
         self.assertTrue("root" in domainJson)
         root_id = domainJson["root"]
@@ -248,9 +242,7 @@ class DomainTest(unittest.TestCase):
         req = helper.getEndpoint() + "/"
         rsp = self.session.get(req, headers=headers)
         if rsp.status_code != 200:
-            msg = f"WARNING: Failed to get domain: {domain}. Is test data setup?"
-            print(msg)
-            return  # abort rest of test
+            self.skipTest(f'{domain}: test data not loaded - see docs/post_install.md')
         domainJson = json.loads(rsp.text)
         self.assertTrue("root" in domainJson)
         root_id = domainJson["root"]
@@ -302,9 +294,7 @@ class DomainTest(unittest.TestCase):
 
         rsp = self.session.get(req, params=params, headers=headers)
         if rsp.status_code == 404:
-            msg = f"WARNING: Failed to get domain: {domain}. Is test data setup?"
-            print(msg)
-            return  # abort rest of test
+            self.skipTest(f'{domain}: test data not loaded - see docs/post_install.md')
         self.assertEqual(rsp.status_code, 200)
         self.assertEqual(rsp.headers["content-type"], "application/json; charset=utf-8")
         rspJson = json.loads(rsp.text)
@@ -1098,9 +1088,7 @@ class DomainTest(unittest.TestCase):
 
         rsp = self.session.get(req, headers=headers)
         if rsp.status_code != 200:
-            msg = f"WARNING: Failed to get domain: {domain}. Is test data setup?"
-            print(msg)
-            return  # abort rest of test
+            self.skipTest(f'{domain}: test data not loaded - see docs/post_install.md')
 
         rspJson = json.loads(rsp.text)
         for k in ("root", "owner", "created", "lastModified"):
@@ -1507,8 +1495,7 @@ class DomainTest(unittest.TestCase):
         req = helper.getEndpoint() + "/"
         rsp = self.session.get(req, headers=headers)
         if rsp.status_code != 200:
-            print(f"WARNING: Failed to get domain: {folder}. Is test data setup?")
-            return  # abort rest of test
+            self.skipTest(f'{folder}: test data not loaded - see docs/post_install.md')
         self.assertEqual(rsp.headers["content-type"], "application/json; charset=utf-8")
         rspJson = json.loads(rsp.text)
 
@@ -1555,8 +1542,7 @@ class DomainTest(unittest.TestCase):
             if name.endswith("tall.h5"):
                 tall_item = item
         if not tall_item:
-            print("WARNING: Failed to get domain. Is test data setup?")
-            return  # abort rest of test
+            self.skipTest('test data not loaded - see docs/post_install.md')
         self.assertEqual(tall_item["class"], "domain")
         self.assertTrue("num_objects" in tall_item)
         self.assertEqual(tall_item["num_objects"], 14)

--- a/tests/integ/group_test.py
+++ b/tests/integ/group_test.py
@@ -94,10 +94,7 @@ class GroupTest(unittest.TestCase):
         req = helper.getEndpoint() + "/"
         rsp = self.session.get(req, headers=headers)
         if rsp.status_code != 200:
-            msg = f"WARNING: Failed to get domain: {domain}. Is test data setup?"
-            print(msg)
-
-            return  # abort rest of test
+            self.skipTest(f'{domain}: test data not loaded - see docs/post_install.md')
 
         rspJson = json.loads(rsp.text)
 
@@ -882,8 +879,7 @@ class GroupTest(unittest.TestCase):
         req = helper.getEndpoint() + "/"
         rsp = self.session.get(req, headers=headers)
         if rsp.status_code != 200:
-            print(f"WARNING: Failed to get domain: {domain}. Is test data setup?")
-            return  # abort rest of test
+            self.skipTest(f'{domain}: test data not loaded - see docs/post_install.md')
 
         rspJson = json.loads(rsp.text)
         root_uuid = rspJson["root"]

--- a/tests/integ/link_test.py
+++ b/tests/integ/link_test.py
@@ -479,8 +479,7 @@ class LinkTest(unittest.TestCase):
         req = helper.getEndpoint() + "/"
         rsp = self.session.get(req, headers=headers)
         if rsp.status_code != 200:
-            print(f"WARNING: Failed to get domain: {domain}. Is test data setup?")
-            return  # abort rest of test
+            self.skipTest(f'{domain}: test data not loaded - see docs/post_install.md')
 
         rspJson = json.loads(rsp.text)
         root_uuid = rspJson["root"]
@@ -570,8 +569,7 @@ class LinkTest(unittest.TestCase):
         req = helper.getEndpoint() + "/"
         rsp = self.session.get(req, headers=headers)
         if rsp.status_code != 200:
-            print(f"WARNING: Failed to get domain: {domain}. Is test data setup?")
-            return  # abort rest of test
+            self.skipTest(f'{domain}: test data not loaded - see docs/post_install.md')
 
         rspJson = json.loads(rsp.text)
         root_uuid = rspJson["root"]
@@ -664,8 +662,7 @@ class LinkTest(unittest.TestCase):
         req = helper.getEndpoint() + "/"
         rsp = self.session.get(req, headers=headers)
         if rsp.status_code != 200:
-            print(f"WARNING: Failed to get domain: {domain}. Is test data setup?")
-            return  # abort rest of test
+            self.skipTest(f'{domain}: test data not loaded - see docs/post_install.md')
 
         rspJson = json.loads(rsp.text)
         root_uuid = rspJson["root"]
@@ -1183,9 +1180,7 @@ class LinkTest(unittest.TestCase):
         req = helper.getEndpoint() + "/"
         rsp = self.session.get(req, headers=headers)
         if rsp.status_code != 200:
-            msg = f"WARNING: Failed to get domain: {domain}. Is test data setup?"
-            print(msg)
-            return  # abort rest of test
+            self.skipTest(f'{domain}: test data not loaded - see docs/post_install.md')
 
         domainJson = json.loads(rsp.text)
         root_id = domainJson["root"]
@@ -1248,9 +1243,7 @@ class LinkTest(unittest.TestCase):
         req = helper.getEndpoint() + "/"
         rsp = self.session.get(req, headers=headers)
         if rsp.status_code != 200:
-            msg = f"WARNING: Failed to get domain: {domain}. Is test data setup?"
-            print(msg)
-            return  # abort rest of test
+            self.skipTest(f'{domain}: test data not loaded - see docs/post_install.md')
 
         domainJson = json.loads(rsp.text)
         root_id = domainJson["root"]

--- a/tests/integ/value_test.py
+++ b/tests/integ/value_test.py
@@ -2453,9 +2453,7 @@ class ValueTest(unittest.TestCase):
         req = helper.getEndpoint() + "/"
         rsp = self.session.get(req, headers=headers)
         if rsp.status_code != 200:
-            msg = f"WARNING: Failed to get domain: {domain}. Is test data setup?"
-            print(msg)
-            return  # abort rest of test
+            self.skipTest(f'{domain}: test data not loaded - see docs/post_install.md')
         domainJson = json.loads(rsp.text)
         root_uuid = domainJson["root"]
         helper.validateId(root_uuid)
@@ -2616,9 +2614,7 @@ class ValueTest(unittest.TestCase):
         req = helper.getEndpoint() + "/"
         rsp = self.session.get(req, headers=headers)
         if rsp.status_code != 200:
-            msg = f"WARNING: Failed to get domain: {domain}. Is test data setup?"
-            print(msg)
-            return  # abort rest of test
+            self.skipTest(f'{domain}: test data not loaded - see docs/post_install.md')
         domainJson = json.loads(rsp.text)
         root_uuid = domainJson["root"]
         helper.validateId(root_uuid)


### PR DESCRIPTION
Two related fixes:

- Reporting skips as success

Tests needing the sample test data checked for it and, when missing, did `print("WARNING: Failed to get domain ... Is test data setup?")` and returned, which unittest counts as a pass.

They explicitly use unittest's skip functionality.

- Duplicate Test Execution

The CI workflow depended on data setup from an initial run of `testall.py`, which is why `testall.py` was run twice (with most tests in the first run doing nothing). The workflow has been reworked to to do that setup directly via `setup_test.py`, and a new `run-tests` flag has been set up to have the job only start the server. testall.py now runs once, against the loaded test data.

The specific setup in question is the creation of /home/<user>/, which hstouch and hsload both need for their tests.