### PR TITLE
Lift the requests upper bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "pyjwt",
     "pytz",
     "pyyaml",
-    "requests <= 2.32.4",
+    "requests",
     "requests-unixsocket",
     "simplejson",
     "s3fs",

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ pytz==2026.3.post1
 PyYAML==6.0.3
 referencing==0.37.0
 requests-unixsocket==0.4.1
-requests==2.32.4
+requests==2.33.0
 rpds-py==2026.6.3
 s3fs==2026.1.0
 setuptools==84.0.0


### PR DESCRIPTION
The `requests <= 2.32.4` cap descends from #363 (2024-05), where `requests <= 2.31.0` accompanied `urllib3 < 2.0.0` to work around `requests-unixsocket` 0.3.x. #430 removed the reason for it by replacing the socket package, but raised the cap to 2.32.4 rather than dropping it — 2.32.4 being just the current release that week.

`requests-unixsocket` 0.4.1 asks only for `requests>=1.1`, and a real unix-socket request with requests 2.33.0 + urllib3 2.7.0 returns 200. Drops the bound and moves the pin to 2.33.0 so CI exercises it — the socket tests are what would catch a regression.