### PR TITLE
fix: reach READY in headless kubernetes deployments

### DIFF
--- a/.github/workflows/k8s-integration.yml
+++ b/.github/workflows/k8s-integration.yml
@@ -1,0 +1,25 @@
+name: k8s integration
+
+# Runs HSDS headless (no head node) on a real k3s cluster and asserts the
+# service nodes actually reach READY and serve requests. Unit tests cannot see
+# this failure mode: it only appears when service nodes discover data nodes
+# through the Kubernetes API, and it presents as healthy pods that 503.
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  headless-k8s:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install k3d
+        run: curl -sSL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+
+      - name: Run headless k8s readiness test
+        run: tests/k8s/run.sh 3

--- a/admin/kubernetes/k8s_deployment_aws.yml
+++ b/admin/kubernetes/k8s_deployment_aws.yml
@@ -59,12 +59,22 @@ spec:
                 secretKeyRef:
                   name: aws-auth-keys
                   key: aws_secret_access_key
+          # asserts node_state, not merely that the process answers: /info is in
+          # INFO_METHODS (hsds_logger.request) and bypasses the node_state gate, so an
+          # httpGet against it returns 200 even while the node is wedged in WAITING and
+          # 503-ing every real request. hsds-node-state takes its port from NODE_TYPE.
           livenessProbe:
-            httpGet:
-              path: /info
-              port: 5101
-            initialDelaySeconds: 5
+            exec:
+              command: ["hsds-node-state"]
+            initialDelaySeconds: 30
             periodSeconds: 60
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command: ["hsds-node-state"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
         - name: dn
           image: hdfgroup/hsds:0.7.0
           imagePullPolicy: IfNotPresent
@@ -102,12 +112,22 @@ spec:
                 secretKeyRef:
                   name: aws-auth-keys
                   key: aws_secret_access_key
+          # asserts node_state, not merely that the process answers: /info is in
+          # INFO_METHODS (hsds_logger.request) and bypasses the node_state gate, so an
+          # httpGet against it returns 200 even while the node is wedged in WAITING and
+          # 503-ing every real request. hsds-node-state takes its port from NODE_TYPE.
           livenessProbe:
-            httpGet:
-              path: /info
-              port: 6101
-            initialDelaySeconds: 5
+            exec:
+              command: ["hsds-node-state"]
+            initialDelaySeconds: 30
             periodSeconds: 60
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command: ["hsds-node-state"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
       volumes:
         - name: accounts
           secret:

--- a/admin/kubernetes/k8s_deployment_azure.yml
+++ b/admin/kubernetes/k8s_deployment_azure.yml
@@ -57,12 +57,22 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+          # asserts node_state, not merely that the process answers: /info is in
+          # INFO_METHODS (hsds_logger.request) and bypasses the node_state gate, so an
+          # httpGet against it returns 200 even while the node is wedged in WAITING and
+          # 503-ing every real request. hsds-node-state takes its port from NODE_TYPE.
           livenessProbe:
-            httpGet:
-              path: /info
-              port: 5101
-            initialDelaySeconds: 5
+            exec:
+              command: ["hsds-node-state"]
+            initialDelaySeconds: 30
             periodSeconds: 60
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command: ["hsds-node-state"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
         - name: dn
           image: hdfgroup/hsds:0.7.0
           imagePullPolicy: IfNotPresent 
@@ -96,12 +106,22 @@ spec:
               secretKeyRef:
                 name: azure-conn-str
                 key: az_conn_str
+          # asserts node_state, not merely that the process answers: /info is in
+          # INFO_METHODS (hsds_logger.request) and bypasses the node_state gate, so an
+          # httpGet against it returns 200 even while the node is wedged in WAITING and
+          # 503-ing every real request. hsds-node-state takes its port from NODE_TYPE.
           livenessProbe:
-            httpGet:
-              path: /info
-              port: 6101
-            initialDelaySeconds: 5
+            exec:
+              command: ["hsds-node-state"]
+            initialDelaySeconds: 30
             periodSeconds: 60
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command: ["hsds-node-state"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
       volumes:
       - name: accounts
         secret:

--- a/admin/kubernetes/k8s_deployment_posix.yml
+++ b/admin/kubernetes/k8s_deployment_posix.yml
@@ -44,12 +44,22 @@ spec:
               value: sn
             - name: HEAD_PORT
               value: "0" # no head container
+          # asserts node_state, not merely that the process answers: /info is in
+          # INFO_METHODS (hsds_logger.request) and bypasses the node_state gate, so an
+          # httpGet against it returns 200 even while the node is wedged in WAITING and
+          # 503-ing every real request. hsds-node-state takes its port from NODE_TYPE.
           livenessProbe:
-            httpGet:
-              path: /info
-              port: 5101
-            initialDelaySeconds: 5
+            exec:
+              command: ["hsds-node-state"]
+            initialDelaySeconds: 30
             periodSeconds: 60
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command: ["hsds-node-state"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
         - name: dn
           image: hdfgroup/hsds:0.7.0
           imagePullPolicy: IfNotPresent
@@ -74,12 +84,22 @@ spec:
               value: dn
             - name: HEAD_PORT
               value: "0" # no head container
+          # asserts node_state, not merely that the process answers: /info is in
+          # INFO_METHODS (hsds_logger.request) and bypasses the node_state gate, so an
+          # httpGet against it returns 200 even while the node is wedged in WAITING and
+          # 503-ing every real request. hsds-node-state takes its port from NODE_TYPE.
           livenessProbe:
-            httpGet:
-              path: /info
-              port: 6101
-            initialDelaySeconds: 5
+            exec:
+              command: ["hsds-node-state"]
+            initialDelaySeconds: 30
             periodSeconds: 60
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command: ["hsds-node-state"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
       volumes:
         - name: data
           hostPath:

--- a/hsds/basenode.py
+++ b/hsds/basenode.py
@@ -160,6 +160,18 @@ async def k8s_update_dn_info(app):
     elif app["dn_urls"] != dn_urls:
         log.info(f"pod ips have changed: {dn_urls}, fetch dn_ids")
         scale_update = True
+    elif app.get("cluster_state") != "READY":
+        # the roster was incomplete last pass - e.g. a dn had not yet assigned
+        # itself a node_number, so it reported -1. Re-fetch until it converges;
+        # keying only off dn_urls changes leaves the cluster wedged in WAITING
+        # forever once the pod set goes stable.
+        #
+        # Costs one /info request per dn per health check, so n^2 across the cluster,
+        # but only while not READY. A cluster that never converges therefore polls
+        # indefinitely where it previously checked once; add backoff here if that
+        # becomes a problem at larger node counts.
+        log.info("cluster_state is not READY, re-fetching dn_ids")
+        scale_update = True
     else:
         scale_update = False
 
@@ -210,14 +222,34 @@ async def k8s_update_dn_info(app):
         log.info(f"scaling - updating dn_ids to: {dn_ids}")
         app["dn_ids"] = dn_ids
 
+        # Any partial view sets WAITING, so a rescale briefly returns 503 until the
+        # roster reconverges - about one health check interval. That is the trade this
+        # gate makes: nodes holding different dn rosters compute different partitions
+        # for the same obj_id, so serving through the churn risks inconsistent reads
+        # rather than a short unavailability.
         if len(dn_ids) != new_count:
             log.warn(f"scaling - got {len(dn_ids)} dn_ids expected {new_count}")
+            app["cluster_state"] = "WAITING"
         elif len(dn_node_numbers) != len(dn_urls):
             log.warn(f"scaling - got {len(dn_node_numbers)} node numbers, expected {new_count}")
+            app["cluster_state"] = "WAITING"
         elif not consecutive:
             log.warn(f"scaling - node_numbers not consecutive - got: {dn_node_numbers}")
+            app["cluster_state"] = "WAITING"
+        elif min_node_count != len(dn_urls) or max_node_count != len(dn_urls):
+            msg = "scaling - dn node_counts have not converged, got range: "
+            msg += f"{min_node_count}-{max_node_count}, expected: {len(dn_urls)}"
+            log.warn(msg)
+            app["cluster_state"] = "WAITING"
         else:
             log.info("scaling - node numbers complete")
+            # No head node exists in this mode to report cluster_state, so derive it
+            # from the dn roster. This deliberately covers only the dn dimension of
+            # isClusterReady(): that function also compares the sn count against
+            # target_sn_count, which is not checked here. getObjPartition() partitions
+            # by dn count, so dn completeness is what decides whether nodes agree on
+            # partitioning - an sn that is not up is simply not serving.
+            app["cluster_state"] = "READY"
 
 
 async def docker_update_dn_info(app):

--- a/hsds/node_state.py
+++ b/hsds/node_state.py
@@ -1,0 +1,59 @@
+##############################################################################
+# Copyright by The HDF Group.                                                #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HSDS (HDF5 Scalable Data Service), Libraries and      #
+# Utilities.  The full HSDS copyright notice, including                      #
+# terms governing use, modification, and redistribution, is contained in     #
+# the file COPYING, which can be found at the root of the source code        #
+# distribution tree.  If you do not have access to this file, you may        #
+# request a copy from help@hdfgroup.org.                                     #
+##############################################################################
+
+"""Print this node's state and exit 0 only when it is READY.
+
+Intended as a container liveness/readiness probe. /info is listed in
+INFO_METHODS in hsds_logger.request and so bypasses the node_state gate, which
+means an httpGet probe against it returns 200 even while the node is stuck in
+WAITING and returning 503 to every real request. A probe that distinguishes a
+serving node from a wedged one therefore has to inspect node_state itself.
+
+The port is derived from NODE_TYPE, so the sn and dn containers can share one
+identical probe command rather than each hardcoding a port.
+
+Exit codes:
+    0  node reports READY
+    1  node reports any other state, or /info could not be reached
+    2  NODE_TYPE has no configured port (misconfiguration, not a wedged node)
+"""
+
+import json
+import os
+import sys
+import urllib.request
+
+from . import config
+
+
+def main():
+    node_type = os.environ.get("NODE_TYPE") or "sn"
+    port = config.get(f"{node_type}_port")
+    if not port:
+        print(f"no port configured for NODE_TYPE={node_type}", file=sys.stderr)
+        return 2
+
+    url = f"http://localhost:{port}/info"
+    try:
+        with urllib.request.urlopen(url, timeout=10) as rsp:
+            state = json.load(rsp)["node"]["state"]
+    except Exception as e:
+        print(f"{url}: {e}", file=sys.stderr)
+        return 1
+
+    # stdout is the state itself, so the same command is useful for diagnostics
+    print(state)
+    return 0 if state == "READY" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,4 +94,5 @@ hsds-servicenode = "hsds.servicenode:main"
 hsds-headnode = "hsds.headnode:main"
 hsds-node = "hsds.node_runner:main"
 hsds-chunklocator = "hsds.chunklocator:main"
+hsds-node-state = "hsds.node_state:main"
 

--- a/tests/k8s/manifests.yaml
+++ b/tests/k8s/manifests.yaml
@@ -1,0 +1,162 @@
+# Minimal HSDS deployment for headless-Kubernetes integration testing.
+#
+# "Headless" means HEAD_PORT=0: there is no head node, so service nodes discover
+# data nodes through the k8s API using k8s_dn_label_selector. That is the code
+# path in k8s_update_dn_info() which, unlike docker_update_dn_info(), has no head
+# node available to tell it the cluster's readiness state.
+#
+# Storage is POSIX so the test needs no cloud credentials and no network egress.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hsds
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: hsds
+rules:
+  # getPodIps() lists every pod in the namespace and filters by label
+  # client-side, so a namespaced list permission is sufficient.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: hsds
+subjects:
+  - kind: ServiceAccount
+    name: hsds
+roleRef:
+  kind: Role
+  name: hsds
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hsds-override
+data:
+  override.yml: |
+    root_dir: /data
+    log_level: INFO
+    # bucket_name (hsdstest), allow_noauth (true) and k8s_dn_label_selector
+    # (app=hsds) all match the shipped defaults in admin/config/config.yml.
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hsds
+spec:
+  selector:
+    app: hsds
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 5101
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hsds
+  labels:
+    app: hsds
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hsds
+  template:
+    metadata:
+      labels:
+        app: hsds
+    spec:
+      serviceAccountName: hsds
+      initContainers:
+        # the POSIX driver expects root_dir/bucket_name to already exist
+        - name: mkbucket
+          image: hsds-test:ci
+          imagePullPolicy: IfNotPresent
+          command: ["mkdir", "-p", "/data/hsdstest"]
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      containers:
+        - name: sn
+          image: hsds-test:ci
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NODE_TYPE
+              value: sn
+            - name: HEAD_PORT
+              value: "0"
+          ports:
+            - containerPort: 5101
+              name: sn
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: override
+              mountPath: /config/override.yml
+              subPath: override.yml
+          # Mirrors admin/kubernetes/: both probes assert node_state via
+          # hsds-node-state, because /info bypasses the gate (INFO_METHODS in
+          # hsds_logger.request) and so an httpGet against it stays green while the
+          # node is wedged in WAITING. The port comes from NODE_TYPE.
+          livenessProbe:
+            exec:
+              command: ["hsds-node-state"]
+            initialDelaySeconds: 30
+            periodSeconds: 60
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command: ["hsds-node-state"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+        - name: dn
+          image: hsds-test:ci
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/sbin/killall5", "-15"]
+          env:
+            - name: NODE_TYPE
+              value: dn
+            - name: HEAD_PORT
+              value: "0"
+          ports:
+            - containerPort: 6101
+              name: dn
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: override
+              mountPath: /config/override.yml
+              subPath: override.yml
+          livenessProbe:
+            exec:
+              command: ["hsds-node-state"]
+            initialDelaySeconds: 30
+            periodSeconds: 60
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command: ["hsds-node-state"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+      volumes:
+        # single-node k3s, so a hostPath is shared by every replica
+        - name: data
+          hostPath:
+            path: /tmp/hsds-test-data
+            type: DirectoryOrCreate
+        - name: override
+          configMap:
+            name: hsds-override

--- a/tests/k8s/run.sh
+++ b/tests/k8s/run.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+#
+# Integration test for HSDS running headless in Kubernetes (k3s via k3d).
+#
+# Guards against the failure mode where service nodes never leave WAITING and
+# every request returns 503. Neither unit tests nor `kubectl get pods` catch it:
+# containers stay Running and their liveness probes stay green, because /info
+# bypasses the node_state gate (see INFO_METHODS in hsds_logger.request).
+# Detecting it needs a real cluster, an explicit readiness assertion, and a
+# request against a *gated* route.
+#
+# The scale-up step is not incidental. Readiness bugs here surface as races
+# during rescale - a data node reporting node_number -1, or two nodes briefly
+# claiming the same number - so a single-replica test can pass while a
+# multi-replica deployment wedges.
+#
+# Readiness is asserted per *container*, not per pod: sn and dn run separate
+# health checks and converge independently, so an sn can report READY while its
+# own dn is still WAITING. Requests that shard to that dn then 503.
+#
+# Usage:
+#   tests/k8s/run.sh [replicas]     # default 3
+#   KEEP=1 tests/k8s/run.sh         # leave the cluster up for debugging
+#
+# Requires: docker, k3d, kubectl.
+
+set -euo pipefail
+
+CLUSTER=hsds-test
+NS=hsds-test
+IMAGE=hsds-test:ci
+REPLICAS="${1:-3}"
+READY_TIMEOUT="${READY_TIMEOUT:-180}"
+# enough requests that round-robin reaches every replica several times
+SERVICE_PROBES="${SERVICE_PROBES:-12}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+
+# Keep this cluster out of ~/.kube/config entirely. Without this, k3d switches the
+# caller's current context to the test cluster, and an aborted run (or KEEP=1)
+# leaves it there - so a later kubectl in the same shell silently targets the
+# wrong cluster. Anyone running this on a machine that also has production
+# credentials should not have their context touched by a test.
+export KUBECONFIG="${TMPDIR:-/tmp}/kubeconfig-${CLUSTER}"
+
+for tool in docker k3d kubectl; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "FATAL: '$tool' not found. Install it (brew install $tool) and retry." >&2
+    exit 1
+  }
+done
+
+cleanup() {
+  if [ "${KEEP:-0}" = "1" ]; then
+    echo
+    echo "KEEP=1 - leaving cluster '$CLUSTER' up. Inspect with:"
+    echo "  kubectl -n $NS get pods"
+    echo "Delete with: k3d cluster delete $CLUSTER"
+  else
+    echo
+    echo "--> tearing down cluster '$CLUSTER'"
+    k3d cluster delete "$CLUSTER" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+pods() {
+  kubectl -n "$NS" get pods -l app=hsds \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null
+}
+
+# node_state of one container in a pod, using the same hsds-node-state script the
+# probes run. It prints the state and derives its port from NODE_TYPE, so no port
+# needs threading through here.
+#
+# `|| true` because it exits non-zero when the node is not READY - correct for a
+# probe, but here we only want the printed state and pipefail would otherwise make
+# a WAITING node indistinguishable from a failed kubectl.
+node_state() { # $1=pod  $2=container
+  kubectl -n "$NS" exec "$1" -c "$2" -- hsds-node-state 2>/dev/null | tr -d '\r\n' || true
+}
+
+# A pod only serves once BOTH its nodes are READY. sn and dn each run their own
+# health check and converge independently, so an sn can report READY while its dn
+# is still WAITING - and a request that shards to that dn gets a 503 from the dn's
+# own gate. Asserting on sn alone lets this test pass while the cluster is not
+# actually serving, which is exactly how it produced a false PASS.
+pod_ready() { # $1=pod
+  [ "$(node_state "$1" sn)" = "READY" ] &&
+    [ "$(node_state "$1" dn)" = "READY" ]
+}
+
+# Status counts for repeated GETs against a *gated* route, via the ClusterIP
+# service. A missing domain gives 404; 503 means a node was not ready, which is the
+# bug this test exists to catch.
+#
+# Sends many requests rather than one: the service load-balances, so a single
+# request only ever exercises one replica and can pass while the others 503.
+service_status_counts() {
+  local pod="$1"
+  kubectl -n "$NS" exec "$pod" -c sn -- python -c "
+import collections, urllib.request, urllib.error, urllib.parse
+url = 'http://hsds.${NS}.svc.cluster.local/?domain=' + urllib.parse.quote('/home/nosuch.h5')
+counts = collections.Counter()
+for _ in range(${SERVICE_PROBES}):
+    try:
+        counts[urllib.request.urlopen(url).status] += 1
+    except urllib.error.HTTPError as e:
+        counts[e.code] += 1
+    except Exception as e:
+        counts[type(e).__name__] += 1
+print(' '.join(f'{k}={v}' for k, v in sorted(counts.items(), key=str)))
+" 2>/dev/null | tr -d '\r\n'
+}
+
+diagnose() {
+  echo
+  echo "===== diagnostics ====="
+  kubectl -n "$NS" get pods -o wide 2>&1 || true
+  echo "--- per-container node_state (sn and dn converge independently) ---"
+  for p in $(pods); do
+    echo "    $p  sn=$(node_state "$p" sn)  dn=$(node_state "$p" dn)"
+  done
+  for p in $(pods); do
+    for c in sn dn; do
+      echo "--- $p ($c) readiness-relevant log lines ---"
+      kubectl -n "$NS" logs "$p" -c "$c" --tail=60 2>&1 |
+        grep -E "node_state|cluster_state|scaling|dn_urls|not consecutive|converged" || true
+    done
+  done
+}
+
+assert_all_ready() {
+  local want="$1" waited=0 ready count p
+  echo "--> waiting for $want pod(s) with BOTH sn and dn READY (timeout ${READY_TIMEOUT}s)"
+  while [ "$waited" -lt "$READY_TIMEOUT" ]; do
+    count=0
+    ready=0
+    for p in $(pods); do
+      count=$((count + 1))
+      pod_ready "$p" && ready=$((ready + 1))
+    done
+    if [ "$count" -eq "$want" ] && [ "$ready" -eq "$want" ]; then
+      echo "    PASS: $ready/$want READY"
+      return 0
+    fi
+    echo "    $ready/$count READY, waiting..."
+    sleep 5
+    waited=$((waited + 5))
+  done
+  echo "    FAIL: only $ready/$want reached READY within ${READY_TIMEOUT}s" >&2
+  diagnose
+  return 1
+}
+
+assert_serving() {
+  local pod counts
+  pod="$(pods | head -1)"
+  counts="$(service_status_counts "$pod")"
+  if [ -z "$counts" ]; then
+    echo "    FAIL: no response from service" >&2
+    diagnose
+    return 1
+  fi
+  case "$counts" in
+    *503*)
+      echo "    FAIL: gated route returned 503 - nodes are not serving: $counts" >&2
+      diagnose
+      return 1
+      ;;
+  esac
+  # anything that is not an HTTP status (an exception class name) is also a failure
+  case "$counts" in
+    *[A-Za-z]=*)
+      echo "    FAIL: request errors against service: $counts" >&2
+      diagnose
+      return 1
+      ;;
+  esac
+  echo "    PASS: ${SERVICE_PROBES} requests via service, no 503 -> $counts"
+}
+
+echo "==> building $IMAGE"
+docker build -q -t "$IMAGE" "$REPO" >/dev/null
+
+echo "==> creating k3d cluster '$CLUSTER'"
+k3d cluster delete "$CLUSTER" >/dev/null 2>&1 || true
+k3d cluster create "$CLUSTER" --wait \
+  --kubeconfig-update-default=false \
+  --kubeconfig-switch-context=false >/dev/null
+k3d kubeconfig get "$CLUSTER" >"$KUBECONFIG"
+
+echo "==> importing $IMAGE into the cluster"
+k3d image import "$IMAGE" -c "$CLUSTER" >/dev/null
+
+echo "==> applying manifests"
+kubectl create namespace "$NS" >/dev/null
+kubectl -n "$NS" apply -f "$HERE/manifests.yaml" >/dev/null
+# Not fatal: the readiness probe means a broken build never reports Ready, so this
+# would abort under `set -e` before the assertions below run - and their output is the
+# whole point, since a bare "timed out waiting for the condition" says nothing about
+# why. Let it fail and let assert_all_ready produce the diagnostics.
+kubectl -n "$NS" rollout status deploy/hsds --timeout=180s || true
+
+echo
+echo "== single replica =="
+assert_all_ready 1
+assert_serving
+
+echo
+echo "== scaled to $REPLICAS replicas =="
+kubectl -n "$NS" scale deploy/hsds --replicas="$REPLICAS" >/dev/null
+kubectl -n "$NS" rollout status deploy/hsds --timeout=300s || true  # see above
+assert_all_ready "$REPLICAS"
+assert_serving
+
+echo
+echo "ALL CHECKS PASSED"


### PR DESCRIPTION
## Summary

On a Kubernetes deployment with no head node, every node stays in `WAITING` for the
lifetime of the process and returns 503 to every request. The cause is a readiness gate
added in `ed6b5a01` that is only ever satisfied by a head node's `/register` response,
so the k8s discovery path can never satisfy it. This is deterministic, not a race, and
independent of replica count.

This fixes it by deriving `cluster_state` from the dn roster in the k8s path, and by
re-checking that roster while a node is not yet READY.

## Why this affects the shipped manifests

All three deployment manifests under `admin/kubernetes/` run headless, each saying so
explicitly:

| manifest | setting |
|---|---|
| `k8s_deployment_aws.yml` | `HEAD_PORT: null # no head container` |
| `k8s_deployment_azure.yml` | `HEAD_PORT: "0" # no head container` |
| `k8s_deployment_posix.yml` | `HEAD_PORT: "0" # no head container` |

None defines a head container, only `NODE_TYPE: sn` and `NODE_TYPE: dn`. Headless is
therefore not an unusual configuration but the only Kubernetes topology this project
documents, which is why the fix belongs in the k8s path rather than in guidance to
deploy a head node.

## Root cause

`ed6b5a01` ("avoid race condition in ready state logic") added a gate in
`updateReadyState()`:

```python
elif app.get("cluster_state") != "READY":
    is_ready = False
```

`cluster_state` is initialised to `"WAITING"` in `baseInit()` and is only ever
reassigned inside `docker_update_dn_info()`, from the head node's `/register` response.
But `update_dn_info()` branches on whether a head url exists:

```python
if "is_k8s" in app and not getHeadUrl(app):
    await k8s_update_dn_info(app)     # never touches cluster_state
else:
    await docker_update_dn_info(app)  # the only writer of cluster_state
```

With no head node the first branch is taken on every health check, so `cluster_state`
never leaves `"WAITING"` and `is_ready` is permanently `False`.

Reproduced at a single replica with a fully converged roster, so no race is involved:

```
scaling - updating dn_ids to: ['dn-d21ee']
scaling - node numbers complete          <- roster complete on the first pass
healthCheck - node_state: WAITING        <- and still never goes READY
```

## Why configuration cannot work around it

`getHeadUrl()` hardcodes `dns_name = "127.0.0.1"` when `KUBERNETES_SERVICE_HOST` is
set, and there is no `head_endpoint`/`head_host` config key, so a head node has to be a
container in the same pod. With N replicas that yields N independent heads, each seeing
only its own pod's sn/dn and each concluding the cluster is complete. Pods would then
disagree on `getObjPartition()` for the same `obj_id`, which is the hazard `ed6b5a01`
set out to prevent.

## The fix

Two changes to `k8s_update_dn_info()`, both using values the function already computes.

**1. Derive `cluster_state` from the dn roster.** The existing `if/elif/else` chain
already separates "roster complete and self-consistent" from every partial state, so
the `else` branch sets `READY` and the partial branches set `WAITING`.

This covers only the **dn** dimension of `isClusterReady()`. That function also
compares the sn count against `target_sn_count`, which is deliberately not checked
here: `getObjPartition()` partitions by dn count, so dn completeness is what decides
whether nodes agree on partitioning, whereas an sn that is not up is simply not
serving. Happy to add an sn-count condition if you would rather the two paths match
exactly, though it would need a `target_sn_count` that headless deployments do not
currently set (it defaults to `0`).

It also enforces the function's own documented condition 1, "node_count ==
len(dn_urls) for all dn's" — `min_node_count`/`max_node_count` were being computed and
then never read.

**2. Re-check the roster while not READY.** `scale_update` was only set when `dn_urls`
changed, which made the roster check one-shot. During a rescale a dn can be observed
before it has assigned its own `node_number` (reporting `-1`), or two dn's can
transiently report the same number. The check logged a warning and, with the pod set
then stable, never ran again, leaving the cluster wedged.

Observed on a 3-replica deployment; every rollout hit one of these transient states:

| observed `dn_node_numbers` | without fix 2 | with fix 2 |
|---|---|---|
| `[-1]` | wedged in WAITING | re-fetched, converged, READY |
| `[-1, 0, 1]` | wedged in WAITING | re-fetched, converged, READY |
| `[0, 1, 1]` | wedged in WAITING | re-fetched, converged, READY |

## Probes in the example manifests

Related, and the reason this outage went unnoticed for as long as it did: all three
manifests pointed their liveness probes at `/info`, which is in `INFO_METHODS` and so
bypasses the `node_state` gate. It returns 200 even while the node is wedged in
`WAITING` and returning 503 to every real request, so pods reported `Running`, never
restarted, and passed every probe throughout a total outage. There were also no
readiness probes, so wedged pods stayed in their Service's endpoints.

Adds a `hsds-node-state` console script that inspects `node_state` and exits non-zero
unless it is `READY`. It takes its port from `NODE_TYPE`, so the sn and dn containers
share one identical command rather than each hardcoding a port:

```yaml
livenessProbe:
  exec:
    command: ["hsds-node-state"]
  initialDelaySeconds: 30
  periodSeconds: 60
  failureThreshold: 5
readinessProbe:
  exec:
    command: ["hsds-node-state"]
  initialDelaySeconds: 5
  periodSeconds: 10
  failureThreshold: 3
```

All three manifests now use it for both probes. Readiness keeps a wedged pod out of the
Service, so a bad rollout stalls with the old pods still serving instead of replacing
them with 503-ing ones. Liveness restarts a genuinely stuck node. Without it, readiness
alone would pull every wedged pod from the Service and nothing would recover them,
leaving zero endpoints indefinitely. The 5 x 60s liveness budget is deliberately far
longer than the ~10s `WAITING` dips a rescale causes, so only a real wedge trips it.

It prints the state on stdout as well, which makes the same command useful for
diagnostics (`kubectl exec ... -- hsds-node-state`).

## Trade-offs worth weighing

Two consequences that reviewers should see up front rather than discover.

**Rescales now briefly return 503.** Any partial view of the roster sets `WAITING`, so
a scale event 503s until the roster reconverges, roughly one health check interval.
Before `ed6b5a01` a node holding a complete `dn_ids` stayed READY through roster churn.
The trade here is inconsistent partitioning versus short unavailability.
Measured on a 3-replica rollout: 2 requests received 503 across the entire rollout.

**Fix 2 polls while not READY.** It costs one `/info` request per dn per health check,
so n² across the cluster, though only while not READY. A cluster that never converges
therefore polls indefinitely where it previously checked once. Negligible at small node
counts; there is a comment marking where backoff would go if it matters at larger
scale.

## Testing

Adds `tests/k8s/`: a k3d integration test that deploys HSDS headless on hermetic POSIX storage, 
asserts every node reaches `READY`, then scales to 3 replicas and re-asserts.

Two properties this failure mode required designing around:

- **`/info` bypasses the `node_state` gate**, so probing it proves nothing about whether
  a node is serving (see the probe section above). The test asserts `node_state`
  explicitly and sends its requests to a *gated* route, where the pass condition is
  "not 503".
- **The race only surfaces on rescale**, so a single-replica test can pass against
  broken code. The test scales up and re-asserts.

Readiness is asserted per *container*. sn and dn run separate health checks and
converge independently, so an sn can report READY while its own dn is still WAITING,
and a request that shards to that dn gets a 503 from the dn's own gate. Asserting on sn
alone produced a false pass during development.

Verified in both directions: fails on the parent commit (`0/1 READY`, `sn=WAITING
dn=WAITING`) 
and passes with this change, holding at `2/3 READY` while a dn converged
rather than falsely reporting `3/3`.

Also adds `.github/workflows/k8s-integration.yml` to run it on push and PR.

Tested on k3s v1.35.5 (via k3d 5.9.0) and on a 3-replica EKS deployment at this commit,
on both `linux/amd64` and `linux/arm64`.