### PR TITLE
fix CI log capture and races

### DIFF
--- a/hsds/async_lib.py
+++ b/hsds/async_lib.py
@@ -514,6 +514,12 @@ async def scanRoot(app, rootid, update=False, bucket=None):
         log.warn(msg)
         return {}
 
+    if rootid in app["deleted_ids"]:
+        # the root went away after this scan was queued - writing .info.json
+        # now would re-create keys that bucketGC has removed, or is removing
+        log.info(f"scanRoot - {rootid} has been deleted, skipping scan")
+        return {}
+
     if not bucket:
         bucket = config.get("bucket_name")
     if not bucket:

--- a/hsds/datanode_lib.py
+++ b/hsds/datanode_lib.py
@@ -539,6 +539,14 @@ async def delete_metadata_obj(app, obj_id, notify=True, root_id=None, bucket=Non
 
     if isValidUuid(obj_id) and isSchema2Id(obj_id):
         if isRootObjId(obj_id):
+            # drop any queued scan for this root.  bucketScan and bucketGC are
+            # independent tasks, so a scan still on the queue would run after
+            # bucketGC has swept the prefix and write db/<root>/.info.json and
+            # .summary.json back into a domain that no longer exists.
+            root_scan_ids = app["root_scan_ids"]
+            if obj_id in root_scan_ids:
+                log.info(f"removing {obj_id} from root_scan_ids")
+                del root_scan_ids[obj_id]
             # add to gc ids so sub-objects will be deleted
             gc_buckets = app["gc_buckets"]
             if bucket not in gc_buckets:

--- a/hsds/hsds_app.py
+++ b/hsds/hsds_app.py
@@ -15,8 +15,12 @@ from h5json.time_util import getNow
 def _enqueue_output(out, queue, loglevel):
     # loglevel is unused: level filtering happens in the node processes
     # themselves (hsds_logger), lines are passed through verbatim
+    #
+    # The pipe is opened in text mode (see Popen below) so readline returns
+    # str, and the sentinel has to be "".  With a bytes sentinel the equality
+    # test never matches at EOF and this loop spins, enqueuing "" forever.
     try:
-        for line in iter(out.readline, b""):
+        for line in iter(out.readline, ""):
             queue.put(line)
         logging.debug("_enqueue_output close()")
         out.close()
@@ -172,24 +176,29 @@ class HsdsApp:
         else:
             f = sys.stdout
 
-        while True:
-            got_output = False
-            for q in self._queues:
-                try:
-                    line = q.get_nowait()  # or q.get(timeout=.1)
-                except queue.Empty:
-                    pass  # no output on this queue yet
-                else:
-                    if isinstance(line, bytes):
-                        # self.log.debug(line.decode("utf-8").strip())
-                        f.write(line.decode("utf-8"))
+        try:
+            while True:
+                got_output = False
+                for q in self._queues:
+                    try:
+                        line = q.get_nowait()  # or q.get(timeout=.1)
+                    except queue.Empty:
+                        pass  # no output on this queue yet
                     else:
-                        f.write(line)
-                    got_output = True
-            if not got_output:
-                break  # all queues empty for now
-        if self._logfile:
-            f.close()
+                        if isinstance(line, bytes):
+                            # self.log.debug(line.decode("utf-8").strip())
+                            f.write(line.decode("utf-8"))
+                        else:
+                            f.write(line)
+                        got_output = True
+                if not got_output:
+                    break  # all queues empty for now
+        finally:
+            # the logfile is opened buffered, so anything written but not
+            # closed is lost - and that tail is exactly what explains a
+            # failure.  Close on every path out, not just the happy one.
+            if self._logfile:
+                f.close()
 
     def check_processes(self):
         # self.log.debug("check processes")
@@ -197,8 +206,11 @@ class HsdsApp:
         for pname in self._processes:
             p = self._processes[pname]
             if p.poll() is not None:
-                result = p.communicate()
-                msg = f"process {pname} ended, result: {result}"
+                # no communicate() here: the reader thread owns p.stdout and
+                # closes it at EOF, so communicate() races it and can raise on
+                # an already closed pipe.  poll() has the returncode already,
+                # and the output has gone to the queue.
+                msg = f"process {pname} ended, returncode: {p.returncode}"
                 self.log.warning(msg)
                 # TBD - restart failed process
 
@@ -368,6 +380,11 @@ class HsdsApp:
             if p.poll():
                 logging.info(f"terminating process {pname}")
                 p.terminate()
+
+        # final drain - the sub-processes have exited, so whatever is still
+        # queued is the tail of the log and no later tick will write it out
+        self.print_process_output()
+
         self._processes = {}  # reset
         for t in self._threads:
             del t

--- a/hsds/util/fileClient.py
+++ b/hsds/util/fileClient.py
@@ -7,7 +7,7 @@ from inspect import iscoroutinefunction
 import time
 import aiofiles
 from aiohttp.web_exceptions import HTTPNotFound, HTTPInternalServerError
-from aiohttp.web_exceptions import HTTPBadRequest
+from aiohttp.web_exceptions import HTTPBadRequest, HTTPException
 from .. import hsds_logger as log
 from .. import config
 
@@ -88,21 +88,24 @@ class FileClient:
         filepath = pp.join(self._root_dir, bucket, key)
         return self._checkPathInRoot(filepath)
 
-    def _getFileStats(self, filepath, data=None):
-        log.debug(f"_getFileStats({filepath})")
-        if data is not None:
-            if not isinstance(data, bytes):
-                msg = "_getFileStats - expected data to be bytes, "
-                msg += "not computing ETag"
-                log.warn(msg)
-                ETag = ""
-            else:
-                hash_object = hashlib.md5(data)
-                ETag = hash_object.hexdigest()
-        else:
+    def _computeETag(self, data=None):
+        """MD5 of the bytes we were handed.  The ETag is a property of the
+        data, not of the file, so this needs no filesystem access."""
+        if data is None:
             msg = "getFileStats - data is None, so ETag will not be computed"
             log.debug(msg)
-            ETag = ""
+            return ""
+        if not isinstance(data, bytes):
+            msg = "_getFileStats - expected data to be bytes, "
+            msg += "not computing ETag"
+            log.warn(msg)
+            return ""
+        hash_object = hashlib.md5(data)
+        return hash_object.hexdigest()
+
+    def _getFileStats(self, filepath, data=None):
+        log.debug(f"_getFileStats({filepath})")
+        ETag = self._computeETag(data)
         try:
             file_stats = stat(filepath)
             key_stats = {
@@ -198,6 +201,11 @@ class FileClient:
             msg = f"CancelledError for get file obj {key}: {cle}"
             log.warn(msg)
             raise
+        except HTTPException:
+            # already carries a status (a 404 from a missing key, a 400 from
+            # the path-in-root check): let it through rather than relabelling
+            # it "Unexpected Exception" and turning it into a 500
+            raise
         except Exception as e:
             self._file_stats_increment("error_count")
             msg = f"Unexpected Exception {type(e)} get get_object {key}: {e}"
@@ -269,7 +277,24 @@ class FileClient:
             msg += f"start={start_time:.4f} finish={finish_time:.4f} "
             msg += f"elapsed={finish_time - start_time:.4f} bytes={len(data)}"
             log.info(msg)
-            write_rsp = self._getFileStats(filepath, data=data)
+            try:
+                write_rsp = self._getFileStats(filepath, data=data)
+            except HTTPNotFound:
+                # The write is the operation and it succeeded - the data
+                # reached the filesystem and close() returned.  A key that has
+                # gone again by the time we stat it was removed concurrently
+                # (bucketGC does exactly this), which is not this call's
+                # failure; the object stores have no such post-condition
+                # either.  Warn so a genuinely broken store still leaves a
+                # trace, and report what we wrote, the way s3Client does.
+                msg = f"fileClient.put_object - {bucket}/{key} not present "
+                msg += "after a successful write (deleted concurrently?)"
+                log.warn(msg)
+                write_rsp = {
+                    "ETag": self._computeETag(data),
+                    "Size": len(data),
+                    "LastModified": finish_time,
+                }
         except IOError as ioe:
             msg = f"fileClient: IOError writing {bucket}/{key}: {ioe}"
             log.warn(msg)
@@ -280,6 +305,11 @@ class FileClient:
             log.warn(msg)
             raise
 
+        except HTTPException:
+            # already carries a status (a 404 from a missing key, a 400 from
+            # the path-in-root check): let it through rather than relabelling
+            # it "Unexpected Exception" and turning it into a 500
+            raise
         except Exception as e:
             # file_stats_increment(app, "error_count")
             msg = f"fileClient Unexpected Exception {type(e)} "
@@ -333,6 +363,11 @@ class FileClient:
             log.warn(msg)
             raise
 
+        except HTTPException:
+            # already carries a status (a 404 from a missing key, a 400 from
+            # the path-in-root check): let it through rather than relabelling
+            # it "Unexpected Exception" and turning it into a 500
+            raise
         except Exception as e:
             self._file_stats_increment("error_count")
             msg = f"Unexpected Exception {type(e)} deleting file obj {key}: {e}"

--- a/hsds/util/fileClient.py
+++ b/hsds/util/fileClient.py
@@ -100,7 +100,11 @@ class FileClient:
             msg += "not computing ETag"
             log.warn(msg)
             return ""
-        hash_object = hashlib.md5(data)
+        # not a security use: this is the S3 ETag convention (a single-part
+        # S3 upload's ETag is the md5 of the object bytes), so the digest has
+        # to stay md5.  The flag says so, and keeps this working on hosts
+        # where FIPS mode makes an unqualified hashlib.md5() raise.
+        hash_object = hashlib.md5(data, usedforsecurity=False)
         return hash_object.hexdigest()
 
     def _getFileStats(self, filepath, data=None):


### PR DESCRIPTION
hsds_app.py - the sub-process reader thread used a bytes sentinel on a
text-mode pipe, so it never stopped at EOF. The drain loop then never
broke and never closed the buffered logfile, so hs.log lost everything
written after the first node exit. This PR fixes the sentinel, has the
log close from a finally block, and drops the p.communicate() that can
race the reader thread for p.stdout.

fileClient.py - put_object stat'd the file it had just written to, so a
concurrent delete could turn a successful write into a 500 spuriously.
This demotes that stat to a warning and falls back to synthesizing the
response, the same approach s3Client already takes. It also stops the
bare `except Exception` from relabelling HTTP statuses as internal
errors, including the path-outside-root 400 raised via _mkdir.

datanode_lib.py, async_lib.py - a deleted root stayed queued in
root_scan_ids, so bucketScan could write .info.json and .summary.json
back into a prefix which bucketGC had just swept. This purges the root
on delete, and has scanRoot bail out if it has been deleted since the
scan was queued.
